### PR TITLE
decode invalid jwt token returns null

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 var jws = require('jws');
 
 module.exports.decode = function (jwt) {
-  return jws.decode(jwt).payload;
+  var decoded = jws.decode(jwt);
+  return decoded && decoded.payload;
 };
 
 module.exports.sign = function(payload, secretOrPrivateKey, options) {

--- a/test/jwt.rs.tests.js
+++ b/test/jwt.rs.tests.js
@@ -135,5 +135,21 @@ describe('RS256', function() {
     });
   });
 
+  describe('when decoding a invalid jwt token', function() {
+    it('should return null', function(done) {
+      var payload = jwt.decode('whatever.token');
+      assert.isNull(payload);
+      done();
+    });
+  });
 
+  describe('when decoding a valid jwt token', function() {
+    it('should return the payload', function(done) {
+      var obj     = { foo: 'bar' };
+      var token   = jwt.sign(obj, priv, { algorithm: 'RS256' });
+      var payload = jwt.decode(token);
+      assert.deepEqual(payload, obj);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
hey guys,
I was trying to decode a jwt token that comes from web ( api ) and works really nice but when I sent an invalid token the decode function blows up.

jws module returns **null** with invalid token

``` js
$ node
> var  jws = require('jws')
> jws.decode('invalid');
null
```

and the [decode function](https://github.com/auth0/node-jsonwebtoken/blob/master/index.js#L4) blows up trying to fetch the payload from null.

``` js
$ node

> jwt = require('./');
{ decode: [Function],
  sign: [Function],
  verify: [Function] }

> jwt.decode('whatever invalid token');
TypeError: Cannot read property 'payload' of null
    at Object.module.exports.decode (/Users/tdantas/Code/PR/node-jsonwebtoken/index.js:4:25)
    at repl:1:5
    at REPLServer.self.eval (repl.js:110:21)
    at repl.js:249:20
    at REPLServer.self.eval (repl.js:122:7)
    at Interface.<anonymous> (repl.js:239:12)
    at Interface.emit (events.js:95:17)
    at Interface._onLine (readline.js:202:10)
    at Interface._line (readline.js:531:8)
    at Interface._ttyWrite (readline.js:760:14)
```

cya
