### PR TITLE
strict check of jwt token part count (avoid "TypeError: Cannot read property 'payload' of null" in some cases)

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   if (!options) options = {};
 
   var parts = jwtString.split('.');
-  if (parts.length < 3)
+  if (parts.length !== 3)
     return callback(new Error('jwt malformed'));
 
   if (parts[2].trim() === '' && secretOrPublicKey)

--- a/test/jwt.rs.tests.js
+++ b/test/jwt.rs.tests.js
@@ -161,6 +161,18 @@ describe('RS256', function() {
     });
   });
 
+  describe('when decoding a jwt token with additional parts', function() {
+    var token = jwt.sign({ foo: 'bar' }, priv, { algorithm: 'RS256' });
+
+    it('should throw', function(done) {
+      jwt.verify(token + '.foo', pub, function(err, decoded) {
+        assert.isUndefined(decoded);
+        assert.isNotNull(err);
+        done();
+      });
+    });
+  });
+
   describe('when decoding a invalid jwt token', function() {
     it('should return null', function(done) {
       var payload = jwt.decode('whatever.token');


### PR DESCRIPTION
May be related to #15
