### PR TITLE
force jws to always parse the payload as JSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var jws = require('jws');
 
 module.exports.decode = function (jwt) {
-  var decoded = jws.decode(jwt);
+  var decoded = jws.decode(jwt, {json: true});
   return decoded && decoded.payload;
 };
 


### PR DESCRIPTION
since the verify code assumes properties like `payload.aud` and `payload.exp` it seems reasonable to force jws to always parse the payload as JSON or else these properties won't exist.
