### PR TITLE
Verifying null fix.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   if ((typeof options === 'function') && !callback) callback = options;
   if (!options) options = {};
 
+  if (!jwtString)
+  	return callback(new JsonWebTokenError('jwt must be provided'));
+
   var parts = jwtString.split('.');
   if (parts.length !== 3)
     return callback(new JsonWebTokenError('jwt malformed'));

--- a/test/jwt.hs.tests.js
+++ b/test/jwt.hs.tests.js
@@ -41,5 +41,13 @@ describe('HS256', function() {
       });
     });
 
+    it('should throw when verifying null', function(done) {
+      jwt.verify(null, 'secret', function(err, decoded) {
+        assert.isUndefined(decoded);
+        assert.isNotNull(err);
+        done();
+      });
+    });
+
   });
 });


### PR DESCRIPTION
When using either socketio-jwt or express-jwt middlewares, if the token provided by the client is null, you'll have an unhandled crash because of an attempt to call .split('.') on null. Line 41 in the modified source, [Line 38 in original source](https://github.com/auth0/node-jsonwebtoken/blob/master/index.js#L38).

Since you cannot expect clean input from the client, this is probably a security issue. You can easily crash a server with express-jwt middleware by setting your Authorization header to "Bearer ". 

Optionally, the value can be validated prior to calling verify but I believe this is a safer fix.

jwt.verify in express-jwt: https://github.com/auth0/express-jwt/blob/master/lib/index.js#L46
jwt.verify in socketio-jwt: https://github.com/auth0/socketio-jwt/blob/master/lib/index.js#L23
