### PR TITLE
Allow sync use of `verify` method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,88 +1,10 @@
+'use strict';
+
 var jws = require('jws');
 
-module.exports.decode = function (jwt) {
-  var decoded = jws.decode(jwt, {json: true});
-  return decoded && decoded.payload;
-};
-
-module.exports.sign = function(payload, secretOrPrivateKey, options) {
-  options = options || {};
-
-  var header = {typ: 'JWT', alg: options.algorithm || 'HS256'};
-
-  payload.iat = Math.floor(Date.now() / 1000);
-
-  if (options.expiresInMinutes) {
-    var ms = options.expiresInMinutes * 60;
-    payload.exp = payload.iat + ms;
-  }
-
-  if (options.audience)
-    payload.aud = options.audience;
-
-  if (options.issuer)
-    payload.iss = options.issuer;
-
-  if (options.subject)
-    payload.sub = options.subject;
-
-  var signed = jws.sign({header: header, payload: payload, secret: secretOrPrivateKey});
-
-  return signed;
-};
-
-module.exports.verify = function(jwtString, secretOrPublicKey, options, callback) {
-  if ((typeof options === 'function') && !callback) callback = options;
-  if (!options) options = {};
-
-  if (!jwtString)
-    return callback(new JsonWebTokenError('jwt must be provided'));
-
-  var parts = jwtString.split('.');
-  if (parts.length !== 3)
-    return callback(new JsonWebTokenError('jwt malformed'));
-
-  if (parts[2].trim() === '' && secretOrPublicKey)
-    return callback(new JsonWebTokenError('jwt signature is required'));
-
-  var valid;
-  try {
-    valid = jws.verify(jwtString, secretOrPublicKey);
-  }
-  catch (e) {
-    return callback(e);
-  }
-
-  if (!valid)
-    return callback(new JsonWebTokenError('invalid signature'));
-
-  var payload;
-
-  try {
-   payload = this.decode(jwtString);
-  } catch(err) {
-    return callback(err);
-  }
-
-  if (payload.exp) {
-    if (Math.floor(Date.now() / 1000) >= payload.exp)
-      return callback(new TokenExpiredError('jwt expired', new Date(payload.exp * 1000)));
-  }
-
-  if (options.audience) {
-    var audiences = Array.isArray(options.audience)? options.audience : [options.audience];
-    if (audiences.indexOf(payload.aud) < 0)
-      return callback(new JsonWebTokenError('jwt audience invalid. expected: ' + payload.aud));
-  }
-
-  if (options.issuer) {
-    if (payload.iss !== options.issuer)
-      return callback(new JsonWebTokenError('jwt issuer invalid. expected: ' + payload.iss));
-  }
-
-  callback(null, payload);
-};
-
+/**
+  Custom exceptions
+  */
 var JsonWebTokenError = module.exports.JsonWebTokenError = function (message, error) {
   Error.call(this, message);
   this.name = 'JsonWebTokenError';
@@ -100,3 +22,104 @@ var TokenExpiredError = module.exports.TokenExpiredError = function (message, ex
 };
 TokenExpiredError.prototype = Object.create(JsonWebTokenError.prototype);
 TokenExpiredError.prototype.constructor = TokenExpiredError;
+
+/**
+  Decode JsonWebToken
+  */
+module.exports.decode = function (jwt) {
+  var decoded = jws.decode(jwt, {json: true});
+  return decoded && decoded.payload;
+};
+
+/**
+  Sign payload
+  */
+module.exports.sign = function (payload, secretOrPrivateKey, options) {
+  options = options || {};
+
+  var header = {typ: 'JWT', alg: options.algorithm || 'HS256'};
+
+  payload.iat = Math.floor(Date.now() / 1000);
+
+  if (options.expiresInMinutes) {
+    var s = options.expiresInMinutes * 60;
+    payload.exp = payload.iat + s;
+  }
+
+  if (options.audience) { payload.aud = options.audience; }
+
+  if (options.issuer) { payload.iss = options.issuer; }
+
+  if (options.subject) { payload.sub = options.subject; }
+
+  var signed = jws.sign({header: header, payload: payload, secret: secretOrPrivateKey});
+
+  return signed;
+};
+
+/**
+  Verify and return decoded JsonWebToken
+  @param {function} [callback] - Optional callback, without it, the method will return synchronously
+  */
+module.exports.verify = function(jwtString, secretOrPublicKey, options, callback) {
+  if ((typeof options === 'function') && !callback) {
+    callback = options;
+    options  = null;
+  }
+
+  try {
+    var payload = this.verifySync(jwtString, secretOrPublicKey, options);
+
+    if (!callback) { return payload; }
+
+    callback(null, payload);
+  } catch (err) {
+    if (!callback) { throw err; }
+
+    callback(err);
+  }
+};
+
+module.exports.verifySync = function(jwtString, secretOrPublicKey, options) {
+  if (!options) { options = {}; }
+
+  if (!jwtString) {
+    throw new JsonWebTokenError('jwt must be provided');
+  }
+
+  var parts = jwtString.split('.');
+  if (parts.length !== 3)
+    throw new JsonWebTokenError('jwt malformed');
+
+  if (parts[2].trim() === '' && secretOrPublicKey)
+    throw new JsonWebTokenError('jwt signature is required');
+
+  var valid = jws.verify(jwtString, secretOrPublicKey); // might throw error
+
+  if (!valid)
+    throw new JsonWebTokenError('invalid signature');
+
+
+  var payload = this.decode(jwtString); // might throw error
+
+  // expiry date
+  if (payload.exp && Math.floor(Date.now() / 1000) >= payload.exp) {
+    throw new TokenExpiredError('jwt expired', new Date(payload.exp * 1000));
+  }
+
+  if (options.audience) {
+    var audiences = Array.isArray(options.audience)? options.audience : [options.audience];
+
+    if (audiences.indexOf(payload.aud) < 0) {
+      throw new JsonWebTokenError('jwt audience invalid. expected: ' + payload.aud);
+    }
+  }
+
+  if (options.issuer) {
+    if (payload.iss !== options.issuer) {
+      throw new JsonWebTokenError('jwt issuer invalid. expected: ' + payload.iss);
+    }
+  }
+
+  return payload;
+}

--- a/test/jwt.hs.tests.js
+++ b/test/jwt.hs.tests.js
@@ -49,12 +49,11 @@ describe('HS256', function() {
       });
     });
 
-    it.only('should throw when the payload is not json', function(done) {
+    it('should throw when the payload is not json', function(done) {
       var token = jwt.sign('bar', 'secret', { algorithm: 'HS256' });
       jwt.verify(token, 'secret', function() {
         done();
       });
     });
-
   });
 });

--- a/test/jwt.tests.js
+++ b/test/jwt.tests.js
@@ -1,0 +1,41 @@
+var jwt = require('../index');
+
+var assert = require('chai').assert;
+
+describe('node-jsonwebtoken interface', function () {
+  describe('verify', function () {
+    describe('without callback', function () {
+      it('returns sync', function () {
+        var token = jwt.sign({ foo: 'bar' }, 'secret'),
+            decoded = jwt.verify(token, 'secret');
+
+        assert.ok(decoded.foo);
+        assert.equal(decoded.foo, 'bar');
+      });
+
+      it('throws exceptions sync', function () {
+        assert.throw(function () { jwt.verify(null, 'secret'); });
+      });
+    });
+
+    describe('with callback', function () {
+      it('returns async', function (done) {
+        var token = jwt.sign({ foo: 'bar' }, 'secret');
+
+        jwt.verify(token, 'secret', function (err, decoded) {
+          assert.ok(decoded.foo);
+          assert.ok(decoded.foo, 'bar');
+          done();
+        });
+      });
+
+      it('throws exceptions to callback', function (done) {
+        jwt.verify(null, 'secret', function (err, decoded) {
+          assert.isUndefined(decoded);
+          assert.isNotNull(err);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR allows for using `verify` synchronously, while not changing the interface (it still works with callbacks!)

@jfromaniello 
