### PR TITLE
Fix issue where expirations set to Unix Time 0 are unchecked.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
     return callback(err);
   }
 
-  if (payload.exp) {
+  if (payload.exp !== undefined) {
     if (Math.floor(Date.now() / 1000) >= payload.exp)
       return callback(new TokenExpiredError('jwt expired', new Date(payload.exp * 1000)));
   }


### PR DESCRIPTION
This is definitely an edge case, but I generated some pre-expired tokens (that expired at unix time 0) for testing purposes. I found that they weren't being checked because of the falsy nature of 0.
