### PR TITLE
Changes aud/iss error to use actual expected value

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Error object:
   * 'jwt malformed'
   * 'jwt signature is required'
   * 'invalid signature'
-  * 'jwt audience invalid. expected: [PAYLOAD AUDIENCE]'
-  * 'jwt issuer invalid. expected: [PAYLOAD ISSUER]'
+  * 'jwt audience invalid. expected: [OPTIONS AUDIENCE]'
+  * 'jwt issuer invalid. expected: [OPTIONS ISSUER]'
 
 ```js
 jwt.verify(token, 'shhhhh', function(err, decoded) {

--- a/index.js
+++ b/index.js
@@ -120,12 +120,12 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
     var match = target.some(function(aud) { return audiences.indexOf(aud) != -1; });
 
     if (!match)
-      return done(new JsonWebTokenError('jwt audience invalid. expected: ' + payload.aud));
+      return done(new JsonWebTokenError('jwt audience invalid. expected: ' + audiences.join(' or ')));
   }
 
   if (options.issuer) {
     if (payload.iss !== options.issuer)
-      return done(new JsonWebTokenError('jwt issuer invalid. expected: ' + payload.iss));
+      return done(new JsonWebTokenError('jwt issuer invalid. expected: ' + options.issuer));
   }
 
   return done(null, payload);


### PR DESCRIPTION
The message part of the JsonWebTokenError generated for `aud` and `iss` mismatch
currently use the [PAYLOAD AUDIENCE] and [PAYLOAD ISSUER] as the expected value.
This leads to confusion.  For example, say a JWT `aud` is set to
`https://localhost` and the expected value is `https://localhost:8443`. The
resulting error message is:

`jwt audience invalid. expected: https://localhost:8443`

Which of courses tells the user that the audience is incorrect, yet the expected
value is the value sent.

This commit changes the error message to use the actual expected values,
[OPTIONS AUDIENCE] and [OPTIONS ISSUER].