### PR TITLE
Assumes jwtString is a JWT

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   var payload;
 
   try {
-   payload = this.decode(jwtString);
+   payload = this.decode(jwtString, {json: true});
   } catch(err) {
     return done(err);
   }


### PR DESCRIPTION
JWS checks for `type: "JWT"` in the JWS header to determine if it should JSON.parse the payload or not. The standard makes this key optional. jsonwebtoken already makes a strong assumption that the JWS is a JWT so we should pass that assumption on the JWS.