### PR TITLE
Update jws to 2.0.0 [UTF-8 encoding support]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonwebtoken",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "JSON Web Token implementation (symmetric and asymmetric)",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "jws": "~1.0.1"
+    "jws": "~2.0.0"
   },
   "devDependencies": {
     "atob": "~1.1.2",

--- a/test/encoding.tests.js
+++ b/test/encoding.tests.js
@@ -5,9 +5,9 @@ var atob = require('atob');
 describe('encoding', function() {
 
   it('should properly encode the token', function () {
-    var expected = 'José';
+    var expected = '你好';
     var token = jwt.sign({ name: expected }, 'shhhhh');
-    var decoded_name = JSON.parse(atob(token.split('.')[1])).name;
+    var decoded_name = JSON.parse(decodeURIComponent(escape(atob(token.split('.')[1])))).name;
     expect(decoded_name).to.equal(expected);
   });
 


### PR DESCRIPTION
In ```node-jws``` [v2.0.0](https://github.com/brianloveswords/node-jws/blob/master/CHANGELOG.md#200---2015-01-30) , default payload encoding changed from ```binary``` to ```utf8```