### PR TITLE
First assume JWT claim set is an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,18 @@ var TokenExpiredError = module.exports.TokenExpiredError = require('./lib/TokenE
 
 module.exports.decode = function (jwt, options) {
   var decoded = jws.decode(jwt, options);
-  return decoded && decoded.payload;
+  var payload = decoded && decoded.payload;
+
+  if(typeof payload === 'string') {
+    try {
+       var obj = JSON.parse(payload);
+       if(typeof obj === 'object') {
+           return obj;
+       }
+    } catch (e) { }
+  }
+
+  return payload;
 };
 
 module.exports.sign = function(payload, secretOrPrivateKey, options) {
@@ -109,7 +120,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   var payload;
 
   try {
-   payload = this.decode(jwtString);
+    payload = this.decode(jwtString);
   } catch(err) {
     return done(err);
   }

--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -1,0 +1,28 @@
+var jwt = require('../index');
+var jws = require('jws');
+var fs = require('fs');
+var path = require('path');
+
+var assert = require('chai').assert;
+
+describe('verify', function() {
+  var pub = fs.readFileSync(path.join(__dirname, 'pub.pem'));
+  var priv = fs.readFileSync(path.join(__dirname, 'priv.pem'));
+
+  it('should first assume JSON claim set', function () {
+    var header = { alg: 'RS256' };
+    var payload = { iat: Math.floor(Date.now() / 1000 ) };
+
+    var signed = jws.sign({
+        header: header,
+        payload: payload,
+        secret: priv,
+        encoding: 'utf8'
+    });
+
+    jwt.verify(signed, pub, {typ: 'JWT'}, function(err, p) {
+        assert.isNull(err);
+        assert.deepEqual(p, payload);
+    });
+  });
+});


### PR DESCRIPTION
draft-ietf-oauth-json-web-token does not require JWT objects to have typ: "JWT"
in their header. Yet it expects that the JWT's claim set be JSON for validation.
See step 10 of draft-ietf-oauth-json-web-token section 7.2 "Validating a JWT".

Prior to this commit JWTs without typ: "JWT" in header are validated without
ever checking the claim set.