### PR TITLE
Fix payload properties when not an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ module.exports.sign = function(payload, secretOrPrivateKey, options) {
 
   var header = ((typeof options.headers === 'object') && options.headers) || {};
 
-  if (typeof payload === 'object') {
+  var pl = {content: payload}
+
+  if (typeof pl.content === 'object') {
     header.typ = 'JWT';
   }
 
@@ -27,7 +29,7 @@ module.exports.sign = function(payload, secretOrPrivateKey, options) {
 
   var timestamp = Math.floor(Date.now() / 1000);
   if (!options.noTimestamp) {
-    payload.iat = timestamp;
+    pl.iat = timestamp;
   }
 
   var expiresInSeconds = options.expiresInMinutes ?
@@ -35,24 +37,24 @@ module.exports.sign = function(payload, secretOrPrivateKey, options) {
       options.expiresInSeconds;
 
   if (expiresInSeconds) {
-    payload.exp = timestamp + expiresInSeconds;
+    pl.exp = timestamp + expiresInSeconds;
   }
 
   if (options.audience)
-    payload.aud = options.audience;
+    pl.aud = options.audience;
 
   if (options.issuer)
-    payload.iss = options.issuer;
+    pl.iss = options.issuer;
 
   if (options.subject)
-    payload.sub = options.subject;
+    pl.sub = options.subject;
 
   var encoding = 'utf8';
   if (options.encoding) {
     encoding = options.encoding;
   }
 
-  var signed = jws.sign({header: header, payload: payload, secret: secretOrPrivateKey, encoding: encoding});
+  var signed = jws.sign({header: header, payload: pl, secret: secretOrPrivateKey, encoding: encoding});
 
   return signed;
 };
@@ -109,7 +111,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   var payload;
 
   try {
-   payload = this.decode(jwtString);
+    payload = this.decode(jwtString);
   } catch(err) {
     return done(err);
   }
@@ -137,5 +139,5 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
       return done(new JsonWebTokenError('jwt issuer invalid. expected: ' + options.issuer));
   }
 
-  return done(null, payload);
+  return done(null, payload.content);
 };


### PR DESCRIPTION
Created this to go along with issue #64. I wasn't sure what to do with 
```
if (typeof pl.content === 'object') {
  header.typ = 'JWT';
}
```

Maybe it should just be set to JWT regardless? The spec seems vague about it.