### PR TITLE
Empty secret or public key

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,9 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
     return done(new JsonWebTokenError('jwt signature is required'));
   }
 
+  if (typeof secretOrPublicKey === "undefined" || secretOrPublicKey === null) // secretOrPublicKey can be empty string
+    return done(new JsonWebTokenError('secret or publick key must be provided'));
+
   if (!options.algorithms) {
     options.algorithms = ~secretOrPublicKey.toString().indexOf('BEGIN CERTIFICATE') ||
                          ~secretOrPublicKey.toString().indexOf('BEGIN PUBLIC KEY') ?

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   }
 
   if (typeof secretOrPublicKey === "undefined" || secretOrPublicKey === null) // secretOrPublicKey can be empty string
-    return done(new JsonWebTokenError('secret or publick key must be provided'));
+    return done(new JsonWebTokenError('secret or public key must be provided'));
 
   if (!options.algorithms) {
     options.algorithms = ~secretOrPublicKey.toString().indexOf('BEGIN CERTIFICATE') ||

--- a/index.js
+++ b/index.js
@@ -107,8 +107,9 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
     return done(new JsonWebTokenError('jwt signature is required'));
   }
 
-  if (typeof secretOrPublicKey === "undefined" || secretOrPublicKey === null) // secretOrPublicKey can be empty string
+  if (!secretOrPublicKey) {
     return done(new JsonWebTokenError('secret or public key must be provided'));
+  }
 
   if (!options.algorithms) {
     options.algorithms = ~secretOrPublicKey.toString().indexOf('BEGIN CERTIFICATE') ||

--- a/test/undefined_secretOrPublickey.tests.js
+++ b/test/undefined_secretOrPublickey.tests.js
@@ -9,12 +9,12 @@ describe('verifying without specified secret or public key', function () {
   it('should not verify null', function () {
     expect(function () {
       jwt.verify(TOKEN, null);
-    }).to.throw(JsonWebTokenError, /secret or publick key must be provided/);
+    }).to.throw(JsonWebTokenError, /secret or public key must be provided/);
   });
 
   it('should not verify undefined', function () {
     expect(function () {
       jwt.verify(TOKEN);
-    }).to.throw(JsonWebTokenError, /secret or publick key must be provided/);
+    }).to.throw(JsonWebTokenError, /secret or public key must be provided/);
   });
 });

--- a/test/undefined_secretOrPublickey.tests.js
+++ b/test/undefined_secretOrPublickey.tests.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var path = require('path');
 var jwt = require('../index');
 var JsonWebTokenError = require('../lib/JsonWebTokenError');
 var expect = require('chai').expect;

--- a/test/undefined_secretOrPublickey.tests.js
+++ b/test/undefined_secretOrPublickey.tests.js
@@ -1,0 +1,21 @@
+var fs = require('fs');
+var path = require('path');
+var jwt = require('../index');
+var JsonWebTokenError = require('../lib/JsonWebTokenError');
+var expect = require('chai').expect;
+
+var TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-IDcSemACt8x4iTMCda8Yhe3iZaWbvV5XKSTbuAn0M';
+
+describe('verifying without specified secret or public key', function () {
+  it('should not verify null', function () {
+    expect(function () {
+      jwt.verify(TOKEN, null);
+    }).to.throw(JsonWebTokenError, /secret or publick key must be provided/);
+  });
+
+  it('should not verify undefined', function () {
+    expect(function () {
+      jwt.verify(TOKEN);
+    }).to.throw(JsonWebTokenError, /secret or publick key must be provided/);
+  });
+});


### PR DESCRIPTION
When secret or key fails to load or is not provided, `verify` can throw error even with callback.

Added check for `null` and `undefined`