### PR TITLE
Update to jws@^3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,11 +117,13 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
 
   }
 
-  if (!jws.isValid(jwtString)) {
+  var decodedToken = jws.decode(jwtString);
+
+  if (!decodedToken) {
     return done(new JsonWebTokenError('invalid token'));
   }
 
-  var header = jws.decode(jwtString).header;
+  var header = decodedToken.header;
 
   if (!~options.algorithms.indexOf(header.alg)) {
     return done(new JsonWebTokenError('invalid signature'));

--- a/index.js
+++ b/index.js
@@ -112,15 +112,25 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
                          ~secretOrPublicKey.toString().indexOf('BEGIN PUBLIC KEY') ?
                           [ 'RS256','RS384','RS512','ES256','ES384','ES512' ] :
                          ~secretOrPublicKey.toString().indexOf('BEGIN RSA PUBLIC KEY') ?
-							[ 'RS256','RS384','RS512' ] :
-							[ 'HS256','HS384','HS512' ];
+                          [ 'RS256','RS384','RS512' ] :
+                          [ 'HS256','HS384','HS512' ];
 
+  }
+
+  if (!jws.isValid(jwtString)) {
+    return done(new JsonWebTokenError('invalid token'));
+  }
+
+  var header = jws.decode(jwtString).header;
+
+  if (!~options.algorithms.indexOf(header.alg)) {
+    return done(new JsonWebTokenError('invalid signature'));
   }
 
   var valid;
 
   try {
-    valid = jws.verify(jwtString, secretOrPublicKey);
+    valid = jws.verify(jwtString, header.alg, secretOrPublicKey);
   } catch (e) {
     return done(e);
   }
@@ -134,11 +144,6 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
     payload = this.decode(jwtString);
   } catch(err) {
     return done(err);
-  }
-
-  var header = jws.decode(jwtString).header;
-  if (!~options.algorithms.indexOf(header.alg)) {
-    return done(new JsonWebTokenError('invalid signature'));
   }
 
   if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   var header = decodedToken.header;
 
   if (!~options.algorithms.indexOf(header.alg)) {
-    return done(new JsonWebTokenError('invalid signature'));
+    return done(new JsonWebTokenError('invalid algorithm'));
   }
 
   var valid;

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "jws": "~2.0.0"
+    "jws": "^3.0.0"
   },
   "devDependencies": {
-    "atob": "~1.1.2",
-    "chai": "~1.10.0",
-    "mocha": "~2.1.0"
+    "atob": "^1.1.2",
+    "chai": "^1.10.0",
+    "mocha": "^2.1.0"
   },
   "engines": {
     "npm": ">=1.4.28"

--- a/test/jwt.rs.tests.js
+++ b/test/jwt.rs.tests.js
@@ -241,7 +241,7 @@ describe('RS256', function() {
       jwt.verify('fruit.fruit.fruit', pub, function(err, decoded) {
         assert.isUndefined(decoded);
         assert.isNotNull(err);
-        assert.equal(err.name, 'Error');
+        assert.equal(err.name, 'JsonWebTokenError');
         done();
       });
     });

--- a/test/wrong_alg.tests.js
+++ b/test/wrong_alg.tests.js
@@ -11,10 +11,32 @@ var pub = fs.readFileSync(path.join(__dirname, 'pub.pem'), 'utf8');
 
 var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
 
-describe('signing with pub key as symmetric', function () {
-  it('should not verify', function () {
-    expect(function () {
-      jwt.verify(TOKEN, pub);
-    }).to.throw(JsonWebTokenError, /invalid signature/);
+describe('when setting a wrong `header.alg`', function () {
+
+  describe('signing with pub key as symmetric', function () {
+    it('should not verify', function () {
+      expect(function () {
+        jwt.verify(TOKEN, pub);
+      }).to.throw(JsonWebTokenError, /invalid algorithm/);
+    });
   });
+
+  describe('signing with pub key as HS256 and whitelisting only RS256', function () {
+    it('should not verify', function () {
+      expect(function () {
+        jwt.verify(TOKEN, pub, {algorithms: ['RS256']});
+      }).to.throw(JsonWebTokenError, /invalid algorithm/);
+    });
+  });
+
+  describe('signing with HS256 and checking with HS384', function () {
+    it('should not verify', function () {
+      expect(function () {
+        var token = jwt.sign({foo: 'bar'}, 'secret', {algorithm: 'HS256'});
+        jwt.verify(token, 'some secret', {algorithms: ['HS384']});
+      }).to.throw(JsonWebTokenError, /invalid algorithm/);
+    });
+  });
+
+
 });


### PR DESCRIPTION
As `jws@3.0.0` changed the verify method signature to be `jws.verify(signature, algorithm, secretOrKey)`, the token header must be decoded first in order to make sure that the `alg` field matches one of the allowed `options.algorithms`. After that, the now validated `header.alg` is passed to `jws.verify`

As the order of steps has changed, the error that was thrown when the JWT was invalid is no longer the `jws` one:

```
{ [Error: Invalid token: no header in signature 'a.b.c'] code: 'MISSING_HEADER', signature: 'a.b.c' }
```

That old error (removed from jws) has been replaced by a `JsonWebTokenError` with message `invalid token`. That's why this change will bump be a major.