### PR TITLE
Fix link to auth0.com in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
The README currently links to https://github.com/auth0/node-jsonwebtoken/blob/master/auth0.com rather than https://auth0.com.