### PR TITLE
Avoid uncaught "SyntaxError: Unexpected token ͧ" error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,12 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
 
   }
 
-  var decodedToken = jws.decode(jwtString);
+  var decodedToken;
+  try {
+    decodedToken = jws.decode(jwtString);
+  } catch(err) {
+    return done(new JsonWebTokenError('invalid token'));
+  }
 
   if (!decodedToken) {
     return done(new JsonWebTokenError('invalid token'));


### PR DESCRIPTION
When .verify() a corrupted JWS (e.g.: malicious user add extra characters in the middle of token) an error is thrown:

``
[ERROR] console - SyntaxError: Unexpected token ͧ
    at Object.parse (native)
    at Object.jwsDecode [as decode] (/www/socketio-jwt/node_modules/jsonwebtoken/node_modules/jws/lib/verify-stream.js:71:20)
    at Object.module.exports.verify (/www/socketio-jwt/node_modules/jsonwebtoken/index.js:120:26)`
 ``

Fix is similar to: https://github.com/auth0/node-jsonwebtoken/issues/14