### PR TITLE
Add option to return header and payload when decoding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,18 @@ jwt.verify(token, cert, { algorithms: ['RS256'] }, function (err, payload) {
 `options`:
 
 * `json`: force JSON.parse on the payload even if the header doesn't contain `"typ":"JWT"`.
+* `complete`: return an object with the decode payload and header.
 
 Example
 
 ```js
 // get the decoded payload ignoring signature, no secretOrPrivateKey needed
 var decoded = jwt.decode(token);
+
+// get the decoded payload and header
+var decoded = jwt.decode(token);
+console.log(decoded.header);
+console.log(decoded.payload)
 ```
 
 ## Errors & Codes

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Example
 var decoded = jwt.decode(token);
 
 // get the decoded payload and header
-var decoded = jwt.decode(token);
+var decoded = jwt.decode(token, {complete: true});
 console.log(decoded.header);
 console.log(decoded.payload)
 ```

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ var TokenExpiredError = module.exports.TokenExpiredError = require('./lib/TokenE
 module.exports.decode = function (jwt, options) {
   options = options || {};
   var decoded = jws.decode(jwt, options);
-  var payload = decoded && decoded.payload;
+  if (!decoded) { return null; }
+  var payload = decoded.payload;
 
   //try parse the payload
   if(typeof payload === 'string') {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var JsonWebTokenError = module.exports.JsonWebTokenError = require('./lib/JsonWe
 var TokenExpiredError = module.exports.TokenExpiredError = require('./lib/TokenExpiredError');
 
 module.exports.decode = function (jwt, options) {
+  options = options || {};
   var decoded = jws.decode(jwt, options);
   var payload = decoded && decoded.payload;
 
@@ -12,11 +13,21 @@ module.exports.decode = function (jwt, options) {
     try {
       var obj = JSON.parse(payload);
       if(typeof obj === 'object') {
-        return obj;
+        payload = obj;
       }
     } catch (e) { }
   }
-
+  
+  //return header if `complete` option is enabled.  header includes claims
+  //such as `kid` and `alg` used to select the key within a JWKS needed to
+  //verify the signature
+  if (options.complete === true) {
+    return {
+      header: decoded.header,
+      payload: payload,
+      signature: decoded.signature
+    }
+  }
   return payload;
 };
 

--- a/test/jwt.rs.tests.js
+++ b/test/jwt.rs.tests.js
@@ -275,5 +275,15 @@ describe('RS256', function() {
       assert.deepEqual(payload, obj);
       done();
     });
+    it('should return the header and payload and signature if complete option is set', function(done) {
+      var obj     = { foo: 'bar' };
+      var token   = jwt.sign(obj, priv, { algorithm: 'RS256' });
+      var decoded = jwt.decode(token, { complete: true });
+      console.log(decoded);
+      assert.deepEqual(decoded.payload, obj);
+      assert.deepEqual(decoded.header, { typ: 'JWT', alg: 'RS256' });
+      assert.ok(typeof decoded.signature == 'string');
+      done();
+    });
   });
 });

--- a/test/jwt.rs.tests.js
+++ b/test/jwt.rs.tests.js
@@ -279,7 +279,6 @@ describe('RS256', function() {
       var obj     = { foo: 'bar' };
       var token   = jwt.sign(obj, priv, { algorithm: 'RS256' });
       var decoded = jwt.decode(token, { complete: true });
-      console.log(decoded);
       assert.deepEqual(decoded.payload, obj);
       assert.deepEqual(decoded.header, { typ: 'JWT', alg: 'RS256' });
       assert.ok(typeof decoded.signature == 'string');


### PR DESCRIPTION
This adds an option to return the header and payload when decoding a token.  The header includes claims such as `kid`, which is needed to support RS* signatures and key rotation, where keys are found in a JWKS.

This is needed for a forthcoming patch to express-jwt, in order to give the header claims to the `secretCallback`