### PR TITLE
Fix typo, line 139 README, complete option for .decode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ jwt.verify(token, cert, { algorithms: ['RS256'] }, function (err, payload) {
 `options`:
 
 * `json`: force JSON.parse on the payload even if the header doesn't contain `"typ":"JWT"`.
-* `complete`: return an object with the decode payload and header.
+* `complete`: return an object with the decoded payload and header.
 
 Example
 


### PR DESCRIPTION
Hi Team! 

Thanks for your work on this module. I found and fixed a simple, one-letter typo in the README. 

*From:*
complete: return an object with the **decode** payload and header.

*To:*
complete: return an object with the **decoded** payload and header.

Please let me know if I need to alter the PR in any way, glad to help.