### PR TITLE
Fix this referring to the global object instead of module.exports in verify()

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ module.exports.verify = function(jwtString, secretOrPublicKey, options, callback
   var payload;
 
   try {
-    payload = this.decode(jwtString);
+    payload = module.exports.decode(jwtString);
   } catch(err) {
     return done(err);
   }


### PR DESCRIPTION
This commit allows you to assign the individual functions to variables, or in ES6 use [destructuring](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) when importing the `jsonwebtoken` module. The only issue was the use of `this` in `decode()`, which has been changed to `module.exports`. 

The use of `this` in `decode()` caused the following error to occur.
```
TypeError: undefined is not a function
    at module.exports.verify (/.../node_modules/jsonwebtoken/index.js:163:20)
```

ES5 code to cause error
```
var JWT = require("jsonwebtoken");
var sign = JWT.sign;
var verify = JWT.verify;
var secret = "test1234";

verify(sign({}, secret), secret);
```

ES6 code to cause error (tested with Babel)
```
import { verify, sign } from "jsonwebtoken";

const secret = "test1234";

verify(sign({}, secret), secret);
```

Edit: Correction, `this` isn't undefined, it points to the global object. `decode()` is undefined on the global object.