### PR TITLE
deprecate expireInMinutes and expireInSeconds - in favor of expires

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ encoded private key for RSA and ECDSA.
 `options`:
 
 * `algorithm` (default: `HS256`)
-* `expiresInMinutes` or `expiresInSeconds`
+* `expiresIn`: expressed in seconds or an string describing a time span [rauchg/ms](https://github.com/rauchg/ms.js). Eg: `60`, `"2 days"`, `"10h"`, `"7d"`
 * `audience`
 * `subject`
 * `issuer`
@@ -35,7 +35,7 @@ encoded private key for RSA and ECDSA.
 If `payload` is not a buffer or a string, it will be coerced into a string
 using `JSON.stringify`.
 
-If any `expiresInMinutes`, `audience`, `subject`, `issuer` are not provided, there is no default. The jwt generated won't include those properties in the payload.
+If any `expiresIn`, `audience`, `subject`, `issuer` are not provided, there is no default. The jwt generated won't include those properties in the payload.
 
 Additional headers can be provided via the `headers` object.
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var jws = require('jws');
+var ms = require('ms');
 
 var JWT = module.exports;
 
@@ -30,7 +31,7 @@ JWT.decode = function (jwt, options) {
       header: decoded.header,
       payload: payload,
       signature: decoded.signature
-    }
+    };
   }
   return payload;
 };
@@ -57,12 +58,34 @@ JWT.sign = function(payload, secretOrPrivateKey, options) {
     payload.iat = payload.iat || timestamp;
   }
 
-  var expiresInSeconds = options.expiresInMinutes ?
-      options.expiresInMinutes * 60 :
-      options.expiresInSeconds;
+  if (options.expiresInSeconds || options.expiresInMinutes) {
+    var deprecated_line;
+    try {
+      deprecated_line = /.*\((.*)\).*/.exec((new Error()).stack.split('\n')[2])[1];
+    } catch(err) {
+      deprecated_line = '';
+    }
 
-  if (expiresInSeconds) {
+    console.warn('jsonwebtoken: expiresInMinutes and expiresInSeconds is deprecated. (' + deprecated_line + ')\n' +
+                 'Use "expiresIn" expressed in seconds.');
+
+    var expiresInSeconds = options.expiresInMinutes ?
+        options.expiresInMinutes * 60 :
+        options.expiresInSeconds;
+
     payload.exp = timestamp + expiresInSeconds;
+  } else if (options.expiresIn) {
+    if (typeof options.expiresIn === 'string') {
+      var milliseconds = ms(options.expiresIn);
+      if (typeof milliseconds === 'undefined') {
+        throw new Error('bad "expiresIn" format: ' + options.expiresIn);
+      }
+      payload.exp = timestamp + milliseconds / 1000;
+    } else if (typeof options.expiresIn === 'number' ) {
+      payload.exp = timestamp + options.expiresIn;
+    } else {
+      throw new Error('"expiresIn" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60');
+    }
   }
 
   if (options.audience)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "jws": "^3.0.0"
+    "jws": "^3.0.0",
+    "ms": "~0.7.1"
   },
   "devDependencies": {
     "atob": "^1.1.2",

--- a/test/expires_format.tests.js
+++ b/test/expires_format.tests.js
@@ -1,0 +1,39 @@
+var jwt = require('../index');
+var expect = require('chai').expect;
+
+describe('expires option', function() {
+
+  it('should work with a number of seconds', function () {
+    var token = jwt.sign({foo: 123}, '123', { expiresIn: 10 });
+    var result = jwt.verify(token, '123');
+    expect(result.exp).to.be.closeTo(Math.floor(Date.now() / 1000) + 10, 0.2);
+  });
+
+  it('should work with a string', function () {
+    var token = jwt.sign({foo: 123}, '123', { expiresIn: '2d' });
+    var result = jwt.verify(token, '123');
+    var two_days_in_secs = 2 * 24 * 60 * 60;
+    expect(result.exp).to.be.closeTo(Math.floor(Date.now() / 1000) + two_days_in_secs, 0.2);
+  });
+
+  it('should work with a string second example', function () {
+    var token = jwt.sign({foo: 123}, '123', { expiresIn: '36h' });
+    var result = jwt.verify(token, '123');
+    var day_and_a_half_in_secs = 1.5 * 24 * 60 * 60;
+    expect(result.exp).to.be.closeTo(Math.floor(Date.now() / 1000) + day_and_a_half_in_secs, 0.2);
+  });
+
+
+  it('should throw if expires has a bad string format', function () {
+    expect(function () {
+      jwt.sign({foo: 123}, '123', { expiresIn: '1 monkey' });
+    }).to.throw(/bad "expiresIn" format: 1 monkey/);
+  });
+
+  it('should throw if expires is not an string or number', function () {
+    expect(function () {
+      jwt.sign({foo: 123}, '123', { expiresIn: { crazy : 213 } });
+    }).to.throw(/"expiresIn" should be a number of seconds or string representing a timespan/);
+  });
+
+});


### PR DESCRIPTION
This change adds a deprecation warning on the confusing `expiresInMinutes` and `expiresInSeconds` options of the sign method.

The new option `expires` accept seconds or an string that represents an amount of time. Examples:

```javascript
jwt.sign({foo: 'bar'}, 'my-secret', { expiresIn: 24 * 60 * 60 });
jwt.sign({foo: 'bar'}, 'my-secret', { expiresIn: '2d' });
jwt.sign({foo: 'bar'}, 'my-secret', { expiresIn: '2 days' });
jwt.sign({foo: 'bar'}, 'my-secret', { expiresIn: '10 hours' });
jwt.sign({foo: 'bar'}, 'my-secret', { expiresIn: '10h' });
```

This should also solve the concern expressed in #87.
