### PR TITLE
Fix options.headers for the sign method

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ JWT.decode = function (jwt, options) {
 JWT.sign = function(payload, secretOrPrivateKey, options) {
   options = options || {};
 
-  var header = ((typeof options.headers === 'object') && options.headers) || {};
+  var header = {};
 
   if (typeof payload === 'object') {
     header.typ = 'JWT';
@@ -46,9 +46,9 @@ JWT.sign = function(payload, secretOrPrivateKey, options) {
 
   header.alg = options.algorithm || 'HS256';
 
-  if (options.header) {
-    Object.keys(options.header).forEach(function (k) {
-      header[k] = options.header[k];
+  if (options.headers) {
+    Object.keys(options.headers).forEach(function (k) {
+      header[k] = options.headers[k];
     });
   }
 


### PR DESCRIPTION
First of all `options.header` was never hit, if you follow the documentation and set your headers via `options.headers`:

```js
if (options.header) {
    Object.keys(options.header).forEach(function (k) {
      header[k] = options.header[k];
    });
  }
```

That would be easy to spot if you had a test coverage tool enabled in your build.

Next - even if you add **s** at the end of `options.header` you still can't override the `alg` header, because having this code:

```js
var header = ((typeof options.headers === 'object') && options.headers) || {};
header.alg = options.algorithm || 'HS256';
```

Actually modifies the `options.headers` before you have the chance to read its value. That's because `headers` is an object (pointer), not a value type.

So the test is pretty simple:

```js
jwt.sign({}, '', {headers:{alg:'RS256'}})
```

That's never going to work!