### PR TITLE
Fix typo in docs to correctly show asymmetric

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ encoded public key for RSA and ECDSA.
 var decoded = jwt.verify(token, 'shhhhh');
 console.log(decoded.foo) // bar
 
-// verify a token symmetric
+// verify a token asymmetric
 jwt.verify(token, 'shhhhh', function(err, decoded) {
   console.log(decoded.foo) // bar
 });


### PR DESCRIPTION
I believe there is a typo in the docs that should say asymmetric instead of symmetric. This potentially could be confusing to readers. I have attached a picture with a red box around what I believe should be changed.

Thanks for the awesome library!

![docstypo](https://cloud.githubusercontent.com/assets/11398534/9750456/f47d12ce-564c-11e5-9b9d-2cd88b0d4105.jpg)


