### PR TITLE
Remove duplicate payload line (fix bug in IE strict mode)

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,6 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
   if(typeof callback === 'function') {
     jws.createSign({
       header: header,
-      payload: payload,
       privateKey: secretOrPrivateKey,
       payload: JSON.stringify(payload)
     }).on('done', callback);


### PR DESCRIPTION
When used with browserify this causes a bug because the payload property is declared twice.