### PR TITLE
Add payload object literal warn to JWT.sign

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
     header.typ = 'JWT';
   }
 
+  if (payload.constructor !== Object && options.keys.length) {
+    console.warn("jsonwebtoken: payload is not an object literal. expiresIn, audience, subject, and issuer may not persist!");
+  }
+
   header.alg = options.algorithm || 'HS256';
 
   if (options.headers) {


### PR DESCRIPTION
Checking the constructor of payload on sign and warning if it's not an object literal.

Helpful for those who tend to only read the code snippets in README.md