### PR TITLE
add clock drift tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ encoded private key for RSA and ECDSA.
 * `issuer`
 * `noTimestamp`
 * `headers`
+* `clockTolerance`
 
 If `payload` is not a buffer or a string, it will be coerced into a string
 using `JSON.stringify`.
@@ -40,6 +41,8 @@ If any `expiresIn`, `audience`, `subject`, `issuer` are not provided, there is n
 Additional headers can be provided via the `headers` object.
 
 Generated jwts will include an `iat` claim by default unless `noTimestamp` is specified.
+The `iat` will be backdated of the amount of seconds specified in `clockTolerance`, if defined. Use this field when the token has to be validated by a machine which may have a slightly different system time due to clock drift.
+
 
 Example
 

--- a/index.js
+++ b/index.js
@@ -53,15 +53,14 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
     });
   }
 
-
-var clockTolerance = 0;
-if (options.clockTolerance) {
-    if (typeof options.clockTolerance === 'number' && options.clockTolerance >= 0) {
-      clockTolerance = options.clockTolerance;
-    } else {
-      throw new Error('"clockTolerance" should be a positive number of milliseconds');
-    }
-}
+  var clockTolerance = 0;
+  if (options.clockTolerance) {
+      if (typeof options.clockTolerance === 'number' && options.clockTolerance >= 0) {
+        clockTolerance = options.clockTolerance;
+      } else {
+        throw new Error('"clockTolerance" should be a positive number of seconds');
+      }
+  }
   var timestamp = Math.floor(Date.now() / 1000);
   if (!options.noTimestamp) {
     payload.iat = payload.iat || timestamp - clockTolerance;

--- a/index.js
+++ b/index.js
@@ -53,9 +53,18 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
     });
   }
 
+
+var clockTolerance = 0;
+if (options.clockTolerance) {
+    if (typeof options.clockTolerance === 'number' && options.clockTolerance >= 0) {
+      clockTolerance = options.clockTolerance;
+    } else {
+      throw new Error('"clockTolerance" should be a positive number of milliseconds');
+    }
+}
   var timestamp = Math.floor(Date.now() / 1000);
   if (!options.noTimestamp) {
-    payload.iat = payload.iat || timestamp;
+    payload.iat = payload.iat || timestamp - clockTolerance;
   }
 
   if (options.expiresInSeconds || options.expiresInMinutes) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonwebtoken",
-  "version": "5.4.1",
+  "version": "5.5.0",
   "description": "JSON Web Token implementation (symmetric and asymmetric)",
   "main": "index.js",
   "scripts": {

--- a/test/clock_tolerance.test.js
+++ b/test/clock_tolerance.test.js
@@ -1,0 +1,18 @@
+var jwt = require('../index');
+var expect = require('chai').expect;
+
+describe('clockTolerance', function() {
+
+  it('should produce tokens slightly backdated', function () {
+    var token = jwt.sign({foo: 123}, 'xxx', { expiresInMinutes: 5 , clockTolerance: 7 });
+    var result = jwt.verify(token, 'xxx');
+    expect(result.iat).to.be.closeTo(Math.floor(Date.now() / 1000) + 7, 0.5);
+  });
+  
+   it('should not produce tokens slightly backdated if not requested', function () {
+    var token = jwt.sign({foo: 123}, 'yyy', { expiresInMinutes: 5 });
+    var result = jwt.verify(token, 'yyy');
+    expect(result.iat).to.be.closeTo(Math.floor(Date.now() / 1000), 0.5);
+  });
+
+});

--- a/test/clock_tolerance.test.js
+++ b/test/clock_tolerance.test.js
@@ -6,7 +6,7 @@ describe('clockTolerance', function() {
   it('should produce tokens slightly backdated', function () {
     var token = jwt.sign({foo: 123}, 'xxx', { expiresInMinutes: 5 , clockTolerance: 7 });
     var result = jwt.verify(token, 'xxx');
-    expect(result.iat).to.be.closeTo(Math.floor(Date.now() / 1000) + 7, 0.5);
+    expect(result.iat).to.be.closeTo(Math.floor(Date.now() / 1000) - 7, 0.5);
   });
   
    it('should not produce tokens slightly backdated if not requested', function () {

--- a/test/clock_tolerance.test.js
+++ b/test/clock_tolerance.test.js
@@ -14,5 +14,11 @@ describe('clockTolerance', function() {
     var result = jwt.verify(token, 'yyy');
     expect(result.iat).to.be.closeTo(Math.floor(Date.now() / 1000), 0.5);
   });
+  
+  it('should throw if clockTolerance is negative', function () {
+    expect(function () {
+      jwt.sign({foo: 123}, '123', { clockTolerance: -3 });
+    }).to.throw(/"clockTolerance" should be a positive number of seconds/);
+  });
 
 });


### PR DESCRIPTION
When I use the library to generate a token which is validated by different machines with a time different by a few seconds, it results as invalid.

This change adds the `ClockTolerance` field, and relative documentation and tests, to allow developers to add some tolerance in this scenario.