### PR TITLE
always use jws.sign such that errors can be at all handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,15 +127,20 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
     encoding = options.encoding;
   }
 
-  if(typeof callback === 'function') {
-    jws.createSign({
-      header: header,
-      privateKey: secretOrPrivateKey,
-      payload: JSON.stringify(payload)
-    }).on('done', callback);
-  } else {
-    return jws.sign({header: header, payload: payload, secret: secretOrPrivateKey, encoding: encoding});
+  var signature = jws.sign({
+    header: header,
+    payload: payload,
+    secret: secretOrPrivateKey,
+    encoding: encoding
+  });
+
+  if (typeof callback === 'function') {
+    process.nextTick(function() {
+      callback(signature);
+    });
   }
+
+  return signature;
 };
 
 JWT.verify = function(jwtString, secretOrPublicKey, options, callback) {


### PR DESCRIPTION
This PR switches `sign` to always use `jws#sign` instead of the streaming interface. Why?

1. I was going to open a PR to handle `error` events from the stream, however `callback` is not an _errback_ (oops!), as such the only way to actually catch/handle errors if for them to throw synchronously - and thus we need to use the more-synchronous method.
2. The stream interface calls `jws#sign` anyway, after buffering input data. In this case, all inputs are already known (and small), meaning the streaming interface just adds overhead
3. Similar to 2, and my sentiment in #111, this is all synchronous anyway, and the callback APIs provide little-to-no value (though atleast `verify` is an errback!)