### PR TITLE
Origin/clock skew tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ encoded public key for RSA and ECDSA.
 * `ignoreExpiration`: if `true` do not validate the expiration of the token.
 * `ignoreNotBefore`...
 * `subject`: if you want to check subject (`sub`), provide a value here
-* `clockTolerance`: number of second to tolerate when checking the `nbf` claim, to deal with small clock differences among different servers
+* `clockTolerance`: number of second to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers
 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If any `expiresIn`, `notBeforeMinutes`, `audience`, `subject`, `issuer` are not 
 
 Additional headers can be provided via the `headers` object.
 
-Generated jwts will include an `iat` claim by default unless `noTimestamp` is specified. If `iat` is inserted in the payload, it will be used instead of the real payload, which can be useful if you want your JWTs to be verified by servers having a slightly backdated clock.
+Generated jwts will include an `iat` (issued at) claim by default unless `noTimestamp` is specified. If `iat` is inserted in the payload, it will be used instead of the real timestamp, which can be useful if you want your JWTs to be verified by servers having a slightly backdated clock.
 
 Example
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ encoded public key for RSA and ECDSA.
 * `ignoreExpiration`: if `true` do not validate the expiration of the token.
 * `ignoreNotBefore`...
 * `subject`: if you want to check subject (`sub`), provide a value here
+* `clockTolerance`: number of second to tolerate when checking the `nbf` claim, to deal with small clock differences among different servers
+
 
 ```js
 // verify a token symmetric - synchronous

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If any `expiresIn`, `notBeforeMinutes`, `audience`, `subject`, `issuer` are not 
 
 Additional headers can be provided via the `headers` object.
 
-Generated jwts will include an `iat` claim by default unless `noTimestamp` is specified.
+Generated jwts will include an `iat` claim by default unless `noTimestamp` is specified. If `iat` is inserted in the payload, it will be used instead of the real payload, which can be useful if you want your JWTs to be verified by servers having a slightly backdated clock.
 
 Example
 
@@ -52,6 +52,8 @@ Example
 // sign with default (HMAC SHA256)
 var jwt = require('jsonwebtoken');
 var token = jwt.sign({ foo: 'bar' }, 'shhhhh');
+//backdate a jwt 30 seconds
+var older_token = jwt.sign({ foo: 'bar', iat: Math.floor(Date.now() / 1000) - 30 }, 'shhhhh'); 
 
 // sign with RSA SHA256
 var cert = fs.readFileSync('private.key');  // get private key

--- a/index.js
+++ b/index.js
@@ -233,7 +233,7 @@ JWT.verify = function(jwtString, secretOrPublicKey, options, callback) {
     if (typeof payload.nbf !== 'number') {
       return done(new JsonWebTokenError('invalid nbf value'));
     }
-    if (payload.nbf > Math.floor(Date.now() / 1000)) {
+    if (payload.nbf > Math.floor(Date.now() / 1000) + (options.clockTolerance || 0)) {
       return done(new NotBeforeError('jwt not active', new Date(payload.nbf * 1000)));
     }
   }
@@ -242,7 +242,7 @@ JWT.verify = function(jwtString, secretOrPublicKey, options, callback) {
     if (typeof payload.exp !== 'number') {
       return done(new JsonWebTokenError('invalid exp value'));
     }
-    if (Math.floor(Date.now() / 1000) >= payload.exp)
+    if (Math.floor(Date.now() / 1000) >= payload.exp + (options.clockTolerance || 0))
       return done(new TokenExpiredError('jwt expired', new Date(payload.exp * 1000)));
   }
 

--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ JWT.verify = function(jwtString, secretOrPublicKey, options, callback) {
     if (typeof payload.iat !== 'number') {
       return done(new JsonWebTokenError('iat required when maxAge is specified'));
     }
-    if (Date.now() - (payload.iat * 1000) > maxAge) {
+    if (Date.now() - (payload.iat * 1000) > maxAge + (options.clockTolerance || 0)) {
       return done(new TokenExpiredError('maxAge exceeded', new Date(payload.iat * 1000 + maxAge)));
     }
   }

--- a/index.js
+++ b/index.js
@@ -77,6 +77,9 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
 
   var timestamp = Math.floor(Date.now() / 1000);
   if (!options.noTimestamp) {
+    if (typeof payload.iat !== 'undefined' && typeof payload.iat !== 'number') {
+      throw new Error('"iat" if present should be a number');
+    }
     payload.iat = payload.iat || timestamp;
   }
 

--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ JWT.verify = function(jwtString, secretOrPublicKey, options, callback) {
     if (typeof payload.iat !== 'number') {
       return done(new JsonWebTokenError('iat required when maxAge is specified'));
     }
-    if (Date.now() - (payload.iat * 1000) > maxAge + (options.clockTolerance || 0)) {
+    if (Date.now() - (payload.iat * 1000) > maxAge + (options.clockTolerance || 0) * 1000) {
       return done(new TokenExpiredError('maxAge exceeded', new Date(payload.iat * 1000 + maxAge)));
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonwebtoken",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "JSON Web Token implementation (symmetric and asymmetric)",
   "main": "index.js",
   "scripts": {

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -6,10 +6,12 @@ describe('signing a token asynchronously', function() {
 
   describe('when signing a token', function() {
     var secret = 'shhhhhh';
-    var syncToken = jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' });
+    //use the same timestamp, or it may differ in the two tokens
+    var currentTimestamp = Math.floor(new Date()/1000);
+    var syncToken = jwt.sign({ foo: 'bar', iat: currentTimestamp }, secret, { algorithm: 'HS256' });
 
     it('should return the same result as singing synchronously', function(done) {
-      jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' }, function (asyncToken) {
+      jwt.sign({ foo: 'bar', iat: currentTimestamp }, secret, { algorithm: 'HS256' }, function (asyncToken) {
         expect(asyncToken).to.be.a('string');
         expect(asyncToken.split('.')).to.have.length(3);
         expect(asyncToken).to.equal(syncToken);

--- a/test/iat.tests.js
+++ b/test/iat.tests.js
@@ -1,0 +1,20 @@
+var jwt = require('../index');
+var expect = require('chai').expect;
+
+describe('iat', function() {
+
+  it('should work with a numeric iat not changing the expiration date', function () {
+    var token = jwt.sign({foo: 123, iat: Math.floor(Date.now() / 1000) - 30}, '123', { expiresIn: 10 });
+    var result = jwt.verify(token, '123');
+    expect(result.exp).to.be.closeTo(Math.floor(Date.now() / 1000) + 10, 0.2);
+  });
+
+
+  it('should throw if iat is not a number', function () {
+    expect(function () {
+      jwt.sign({foo: 123, iat:'hello'}, '123');
+    }).to.throw(/"iat" if present should be a number/);
+  });
+
+
+});

--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -15,16 +15,16 @@ describe('verify', function() {
     var payload = { iat: Math.floor(Date.now() / 1000 ) };
 
     var signed = jws.sign({
-        header: header,
+      header: header,
         payload: payload,
         secret: priv,
         encoding: 'utf8'
     });
 
     jwt.verify(signed, pub, {typ: 'JWT'}, function(err, p) {
-        assert.isNull(err);
-        assert.deepEqual(p, payload);
-        done();
+      assert.isNull(err);
+      assert.deepEqual(p, payload);
+      done();
     });
   });
 
@@ -32,7 +32,7 @@ describe('verify', function() {
     // { foo: 'bar', iat: 1437018582, exp: 1437018583 }
     var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MzcwMTg1ODIsImV4cCI6MTQzNzAxODU4M30.NmMv7sXjM1dW0eALNXud8LoXknZ0mH14GtnFclwJv0s';
     var key = 'key';
-      
+
     var clock;
     afterEach(function () {
       try { clock.restore(); } catch (e) {}
@@ -52,9 +52,20 @@ describe('verify', function() {
       });
     });
 
-    it('should not error on unexpired token', function (done) {
-      clock = sinon.useFakeTimers(1437018582000);
-      var options = {algorithms: ['HS256']}
+    it('should not error on expired token within clockTolerance interval', function (done) {
+      clock = sinon.useFakeTimers(1437018584000);
+      var options = {algorithms: ['HS256'], clockTolerance: 100}
+
+      jwt.verify(token, key, options, function (err, p) {
+        assert.isNull(err);
+        assert.equal(p.foo, 'bar');
+        done();
+      });
+    });
+
+    it('should not error if within maxAge timespan', function (done) {
+      clock = sinon.useFakeTimers(1437018582500);
+      var options = {algorithms: ['HS256'], maxAge: '600ms'};
 
       jwt.verify(token, key, options, function (err, p) {
         assert.isNull(err);
@@ -77,10 +88,22 @@ describe('verify', function() {
           done();
         });
       });
+
+      it('should not error for claims issued before a certain timespan but still inside clockTolerance timespan', function (done) {
+        clock = sinon.useFakeTimers(1437018582500);
+        var options = {algorithms: ['HS256'], maxAge: '321ms', clockTolerance: 100};
+
+        jwt.verify(token, key, options, function (err, p) {
+          assert.isNull(err);
+          assert.equal(p.foo, 'bar');
+          done();
+        });
+      });
+
       it('should not error if within maxAge timespan', function (done) {
         clock = sinon.useFakeTimers(1437018582500);
         var options = {algorithms: ['HS256'], maxAge: '600ms'};
-        
+
         jwt.verify(token, key, options, function (err, p) {
           assert.isNull(err);
           assert.equal(p.foo, 'bar');
@@ -90,7 +113,7 @@ describe('verify', function() {
       it('can be more restrictive than expiration', function (done) {
         clock = sinon.useFakeTimers(1437018582900);
         var options = {algorithms: ['HS256'], maxAge: '800ms'};
-        
+
         jwt.verify(token, key, options, function (err, p) {
           assert.equal(err.name, 'TokenExpiredError');
           assert.equal(err.message, 'maxAge exceeded');
@@ -103,7 +126,7 @@ describe('verify', function() {
       it('cannot be more permissive than expiration', function (done) {
         clock = sinon.useFakeTimers(1437018583100);
         var options = {algorithms: ['HS256'], maxAge: '1200ms'};
-        
+
         jwt.verify(token, key, options, function (err, p) {
           // maxAge not exceded, but still expired
           assert.equal(err.name, 'TokenExpiredError');
@@ -118,7 +141,7 @@ describe('verify', function() {
         clock = sinon.useFakeTimers(1437018582900);
         var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIifQ.0MBPd4Bru9-fK_HY3xmuDAc6N_embknmNuhdb9bKL_U';
         var options = {algorithms: ['HS256'], maxAge: '1s'};
-        
+
         jwt.verify(token, key, options, function (err, p) {
           assert.equal(err.name, 'JsonWebTokenError');
           assert.equal(err.message, 'iat required when maxAge is specified');


### PR DESCRIPTION
As discussed in a [previous PR](https://github.com/auth0/node-jsonwebtoken/pull/146), three changes:

-     documenting in the README that the iat can be put _in the payload_
-     introduce a check for the iat to be a number
-     introduce the clockTolerance field in the verify function
