### PR TITLE
feat: change .sign to standard async callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,11 @@ JWT.sign = function(payload, secretOrPrivateKey, options, callback) {
       header: header,
       privateKey: secretOrPrivateKey,
       payload: JSON.stringify(payload)
-    }).on('done', callback);
+    })
+    .on('error', callback)
+    .on('done', function(signature) {
+      callback(null, signature);
+    });
   } else {
     return jws.sign({header: header, payload: payload, secret: secretOrPrivateKey, encoding: encoding});
   }

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -9,10 +9,17 @@ describe('signing a token asynchronously', function() {
     var syncToken = jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' });
 
     it('should return the same result as singing synchronously', function(done) {
-      jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' }, function (asyncToken) {
+      jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' }, function (err, asyncToken) {
         expect(asyncToken).to.be.a('string');
         expect(asyncToken.split('.')).to.have.length(3);
         expect(asyncToken).to.equal(syncToken);
+        done();
+      });
+    });
+
+    it('should throw error', function(done) {
+      jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS2561' }, function (err) {
+        expect(err).to.be.ok();
         done();
       });
     });


### PR DESCRIPTION
- subscribe error event
- change the first argument of the callback as error