### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
Link was going relative to the repo instead of to the external domain.