### PR TITLE
Use lodash.once instead of unlicensed/unmaintained cb

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "cb": "^0.1.0",
     "joi": "^6.10.1",
     "jws": "^3.1.3",
+    "lodash.once": "^4.0.0",
     "ms": "^0.7.1",
     "xtend": "^4.0.1"
   },

--- a/sign.js
+++ b/sign.js
@@ -2,7 +2,7 @@ var Joi = require('joi');
 var timespan = require('./lib/timespan');
 var xtend = require('xtend');
 var jws = require('jws');
-var cb = require('cb');
+var once = require('lodash.once');
 
 var sign_options_schema = Joi.object().keys({
   expiresIn: [Joi.number().integer(), Joi.string()],
@@ -129,7 +129,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
   var encoding = options.encoding || 'utf8';
 
   if (typeof callback === 'function') {
-    callback = callback && cb(callback).once();
+    callback = callback && once(callback);
 
     jws.createSign({
       header: header,


### PR DESCRIPTION
I am trying to get all our dependencies (including transient) to have proper license info, so we can automate the checking. We found that 'cb' doesn't have a license set (in the published version), and haven't seen any activity for over 3 years.

This switches to use lodash.once instead, which should be as small and as efficient.