### PR TITLE
Edit readme to include caution about excessive payload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install jsonwebtoken
 
 (Synchronous) Returns the JsonWebToken as string
 
-`payload` could be an object literal, buffer or string. *Please note that* `exp` is only set if the payload is an object literal.
+`payload` could be an object literal, buffer or string. *Please note that* `exp` is only set if the payload is an object literal. Payloads that are excessively large will cause errors.
 
 `secretOrPrivateKey` is a string or buffer containing either the secret for HMAC algorithms, or the PEM
 encoded private key for RSA and ECDSA.


### PR DESCRIPTION
This might be a rookie mistake, but I got the initial /authenticate route working, and it returned the correct token, but on every subsequent request, the payload information was being lost.

I eventually figured out that it had something to do with the size of the payload I was including. I was including all the user properties in the payload. If you limit it to one or two, things started to work!

I'd like to update the readme to mention this limit. Might save some others some grief! 
