### PR TITLE
Removed the double decoding

### DIFF
--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -11,7 +11,7 @@ describe('verify', function() {
   var priv = fs.readFileSync(path.join(__dirname, 'priv.pem'));
 
   it('should first assume JSON claim set', function (done) {
-    var header = { alg: 'RS256' };
+    var header = { typ: 'JWT', alg: 'RS256' };
     var payload = { iat: Math.floor(Date.now() / 1000 ) };
 
     var signed = jws.sign({
@@ -21,7 +21,7 @@ describe('verify', function() {
         encoding: 'utf8'
     });
 
-    jwt.verify(signed, pub, {typ: 'JWT'}, function(err, p) {
+    jwt.verify(signed, pub, function(err, p) {
       assert.isNull(err);
       assert.deepEqual(p, payload);
       done();
@@ -29,7 +29,7 @@ describe('verify', function() {
   });
 
   it('should be able to validate unsigned token', function (done) {
-    var header = { alg: 'none' };
+    var header = { typ: 'JWT', alg: 'none' };
     var payload = { iat: Math.floor(Date.now() / 1000 ) };
 
     var signed = jws.sign({
@@ -39,7 +39,7 @@ describe('verify', function() {
       encoding: 'utf8'
     });
 
-    jwt.verify(signed, null, {typ: 'JWT'}, function(err, p) {
+    jwt.verify(signed, null, function(err, p) {
       assert.isNull(err);
       assert.deepEqual(p, payload);
       done();
@@ -93,7 +93,7 @@ describe('verify', function() {
 
     it('should not error on expired token within clockTolerance interval', function (done) {
       clock = sinon.useFakeTimers(1437018584000);
-      var options = {algorithms: ['HS256'], clockTolerance: 100}
+      var options = {algorithms: ['HS256'], clockTolerance: 100};
 
       jwt.verify(token, key, options, function (err, p) {
         assert.isNull(err);

--- a/verify.js
+++ b/verify.js
@@ -96,13 +96,7 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   if (!valid)
     return done(new JsonWebTokenError('invalid signature'));
 
-  var payload;
-
-  try {
-    payload = decode(jwtString);
-  } catch(err) {
-    return done(err);
-  }
+  var payload=decodedToken.payload;
 
   if (typeof payload.nbf !== 'undefined' && !options.ignoreNotBefore) {
     if (typeof payload.nbf !== 'number') {


### PR DESCRIPTION
This now works. The tests were wrongly putting typ: 'JWT' in the options instead of the header.
This caused jws.decode to not run a JSON parse. Now tests are passing fine.
Please also review the other tests that are putting typ: 'JWT' in the options. There is no point for that, as options.typ is not checked at all.
