### PR TITLE
Add the expirationRequired option

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ encoded public key for RSA and ECDSA.
 * `audience`: if you want to check audience (`aud`), provide a value here
 * `issuer` (optional): string or array of strings of valid values for the `iss` field.
 * `ignoreExpiration`: if `true` do not validate the expiration of the token.
+* `expirationRequired` if `true`, an expiration must be specified. May become default in the future.
 * `ignoreNotBefore`...
 * `subject`: if you want to check subject (`sub`), provide a value here
 * `clockTolerance`: number of second to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers

--- a/verify.js
+++ b/verify.js
@@ -113,7 +113,10 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     }
   }
 
-  if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {
+  if (!options.ignoreExpiration) {
+    if (typeof payload.exp === 'undefined' && options.expirationRequired) {
+      return done(new JsonWebTokenError('exp required when expirationRequired is true'));
+    }
     if (typeof payload.exp !== 'number') {
       return done(new JsonWebTokenError('invalid exp value'));
     }


### PR DESCRIPTION
Adds the expirationRequired option to the verify method. When this is present and set to true, the exp header must exist or the verification will fail immediately.
