### PR TITLE
Add clockTimestamp option to .verify() you can set the current time in seconds with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ encoded public key for RSA and ECDSA.
 * `ignoreNotBefore`...
 * `subject`: if you want to check subject (`sub`), provide a value here
 * `clockTolerance`: number of seconds to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers
+* `maxAge`: the maximum allowed age in milliseconds for tokens to still be valid. We advise against using milliseconds precision, though, since JWTs can only contain seconds. The maximum precision might be reduced to seconds in the future
+* `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons (also against `maxAge`, so our advise is to avoid using `clockTimestamp` and a `maxAge` in milliseconds together)
 
 
 ```js

--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -189,6 +189,145 @@ describe('verify', function() {
         });
       });
     });
-  });
 
+    describe('option: clockTimestamp', function () {
+      var clockTimestamp = 1000000000;
+      it('should verify unexpired token relative to user-provided clockTimestamp', function (done) {
+        var token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp + 1}, key);
+        jwt.verify(token, key, {clockTimestamp: clockTimestamp}, function (err, p) {
+          assert.isNull(err);
+          done();
+        });
+      });
+      it('should error on expired token relative to user-provided clockTimestamp', function (done) {
+        var token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp + 1}, key);
+        jwt.verify(token, key, {clockTimestamp: clockTimestamp + 1}, function (err, p) {
+          assert.equal(err.name, 'TokenExpiredError');
+          assert.equal(err.message, 'jwt expired');
+          assert.equal(err.expiredAt.constructor.name, 'Date');
+          assert.equal(Number(err.expiredAt), (clockTimestamp + 1) * 1000);
+          assert.isUndefined(p);
+          done();
+        });
+      });
+      it('should verify clockTimestamp is a number', function (done) {
+        var token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp + 1}, key);
+        jwt.verify(token, key, {clockTimestamp: 'notANumber'}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message,'clockTimestamp must be a number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+      it('should verify valid token with nbf', function (done) {
+        var token = jwt.sign({
+          foo: 'bar',
+          iat: clockTimestamp,
+          nbf: clockTimestamp + 1,
+          exp: clockTimestamp + 2
+        }, key);
+        jwt.verify(token, key, {clockTimestamp: clockTimestamp + 1}, function (err, p) {
+          assert.isNull(err);
+          done();
+        });
+      });
+      it('should error on token used before nbf', function (done) {
+        var token = jwt.sign({
+          foo: 'bar',
+          iat: clockTimestamp,
+          nbf: clockTimestamp + 1,
+          exp: clockTimestamp + 2
+        }, key);
+        jwt.verify(token, key, {clockTimestamp: clockTimestamp}, function (err, p) {
+          assert.equal(err.name, 'NotBeforeError');
+          assert.equal(err.date.constructor.name, 'Date');
+          assert.equal(Number(err.date), (clockTimestamp + 1) * 1000);
+          assert.isUndefined(p);
+          done();
+        });
+      });
+    });
+
+    describe('option: maxAge and clockTimestamp', function () {
+      // { foo: 'bar', iat: 1437018582, exp: 1437018800 }
+      var token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MzcwMTg1ODIsImV4cCI6MTQzNzAxODgwMH0.AVOsNC7TiT-XVSpCpkwB1240izzCIJ33Lp07gjnXVpA';
+      it('should error for claims issued before a certain timespan', function (done) {
+        var clockTimestamp = 1437018682;
+        var options = {algorithms: ['HS256'], clockTimestamp: clockTimestamp, maxAge: '1m'};
+
+        jwt.verify(token, key, options, function (err, p) {
+          assert.equal(err.name, 'TokenExpiredError');
+          assert.equal(err.message, 'maxAge exceeded');
+          assert.equal(err.expiredAt.constructor.name, 'Date');
+          assert.equal(Number(err.expiredAt), 1437018642000);
+          assert.isUndefined(p);
+          done();
+        });
+      });
+      it('should not error for claims issued before a certain timespan but still inside clockTolerance timespan', function (done) {
+        var clockTimestamp = 1437018582;
+        var options = {
+          algorithms: ['HS256'],
+          clockTimestamp: clockTimestamp,
+          maxAge: '321ms',
+          clockTolerance: 100
+        };
+
+        jwt.verify(token, key, options, function (err, p) {
+          assert.isNull(err);
+          assert.equal(p.foo, 'bar');
+          done();
+        });
+      });
+      it('should not error if within maxAge timespan', function (done) {
+        var clockTimestamp = 1437018582;
+        var options = {algorithms: ['HS256'], clockTimestamp: clockTimestamp, maxAge: '600ms'};
+
+        jwt.verify(token, key, options, function (err, p) {
+          assert.isNull(err);
+          assert.equal(p.foo, 'bar');
+          done();
+        });
+      });
+      it('can be more restrictive than expiration', function (done) {
+        var clockTimestamp = 1437018588;
+        var options = {algorithms: ['HS256'], clockTimestamp: clockTimestamp, maxAge: '5s'};
+
+        jwt.verify(token, key, options, function (err, p) {
+          assert.equal(err.name, 'TokenExpiredError');
+          assert.equal(err.message, 'maxAge exceeded');
+          assert.equal(err.expiredAt.constructor.name, 'Date');
+          assert.equal(Number(err.expiredAt), 1437018587000);
+          assert.isUndefined(p);
+          done();
+        });
+      });
+      it('cannot be more permissive than expiration', function (done) {
+        var clockTimestamp = 1437018900;
+        var options = {algorithms: ['HS256'], clockTimestamp: clockTimestamp, maxAge: '1000y'};
+
+        jwt.verify(token, key, options, function (err, p) {
+          // maxAge not exceded, but still expired
+          assert.equal(err.name, 'TokenExpiredError');
+          assert.equal(err.message, 'jwt expired');
+          assert.equal(err.expiredAt.constructor.name, 'Date');
+          assert.equal(Number(err.expiredAt), 1437018800000);
+          assert.isUndefined(p);
+          done();
+        });
+      });
+      it('should error if maxAge is specified but there is no iat claim', function (done) {
+        var clockTimestamp = 1437018582;
+        var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIifQ.0MBPd4Bru9-fK_HY3xmuDAc6N_embknmNuhdb9bKL_U';
+        var options = {algorithms: ['HS256'], clockTimestamp: clockTimestamp, maxAge: '1s'};
+
+        jwt.verify(token, key, options, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'iat required when maxAge is specified');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR enables passing a value `now` to the verify function that is then used instead of `Date.now()` (or rather `Math.floor(Date.now()/1000`).
Tackles https://github.com/auth0/node-jsonwebtoken/issues/240.
I didn't change the logic of `options.maxAge` because it uses milli seconds which seemed weird to use as a unit for `options.now`. (See https://github.com/auth0/node-jsonwebtoken/issues/273)