### PR TITLE
Upgrade Joi dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
-before_install: npm i -g npm@1.4.28
+sudo: false
+before_install: npm i -g npm
 node_js:
+  - "7"
+  - "6"
   - "5"
   - "4"
-  - "0.12"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "joi": "^6.10.1",
+    "joi": "^10.0.1",
     "jws": "^3.1.3",
     "lodash.once": "^4.0.0",
     "ms": "^0.7.1",


### PR DESCRIPTION
~~Joi pre-v10 had an older, [vulnerable](https://snyk.io/vuln/npm:moment:20161019) version of moment as dependency, v10 no longer does.~~ (it's been pointed out to me that vulnerable moment was included due to another dependency locking the version down - Joi permits newer versions - but I think this PR still makes sense, as Joi 10 does not depend on moment at all) The breaking changes in v7 to v10 don't seem to be relevant to this codebase (other than introduction of ES6).

I also hope nobody minds that I updated the Travis setup to include latest versions of node and npm. This also removes node 0.12 from test matrix - Joi v7 deprecated that and v0.12 is EOL at the end of December anyways.