### PR TITLE
Implemented keyid (kid) attribute in JWT header (Part II)

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -14,7 +14,8 @@ var sign_options_schema = Joi.object().keys({
   issuer: Joi.string(),
   subject: Joi.string(),
   jwtid: Joi.string(),
-  noTimestamp: Joi.boolean()
+  noTimestamp: Joi.boolean(),
+  keyid: Joi.string()
 });
 
 var registered_claims_schema = Joi.object().keys({
@@ -49,7 +50,8 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
 
   var header = xtend({
     alg: options.algorithm || 'HS256',
-    typ: isObjectPayload ? 'JWT' : undefined
+    typ: isObjectPayload ? 'JWT' : undefined,
+    kid: options.keyid
   }, options.header);
 
   function failure(err) {

--- a/test/keyid.tests.js
+++ b/test/keyid.tests.js
@@ -1,0 +1,9 @@
+var jwt = require('../index');
+
+var claims = {"name": "doron", "age": 46};
+jwt.sign(claims, 'secret', {"keyid": "1234"}, function(err, good) {
+    console.log(jwt.decode(good, {"complete": true}).header.kid);
+    jwt.verify(good, 'secret', function(err, result) {
+        console.log(result);
+    })
+});


### PR DESCRIPTION
Identical to #249, but avoids unnecessary changes.