### PR TITLE
Raise jws.decode error to avoid confusion with "invalid token" error 

### DIFF
--- a/test/jwt.hs.tests.js
+++ b/test/jwt.hs.tests.js
@@ -77,6 +77,21 @@ describe('HS256', function() {
         done();
       });
     });
-
   });
+
+  describe('should fail verification graceflly with trailing space in the jwt', function() {
+    var secret = 'shhhhhh';
+    var token  = jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' });
+
+    it('should return the "invalid token" error', function(done) {
+      var malformedToken = token + ' '; // corrupt the token by adding a space
+      jwt.verify(malformedToken, secret, { algorithm: 'HS256', ignoreExpiration: true }, function(err, decoded) {
+        assert.isNotNull(err);
+        assert.equal('JsonWebTokenError', err.name);
+        assert.equal('invalid token', err.message);
+        done();
+      });
+    });
+  });
+
 });

--- a/test/jwt.hs.tests.js
+++ b/test/jwt.hs.tests.js
@@ -79,7 +79,7 @@ describe('HS256', function() {
     });
   });
 
-  describe('should fail verification graceflly with trailing space in the jwt', function() {
+  describe('should fail verification gracefully with trailing space in the jwt', function() {
     var secret = 'shhhhhh';
     var token  = jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' });
 

--- a/verify.js
+++ b/verify.js
@@ -72,11 +72,11 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   try {
     decodedToken = jws.decode(jwtString);
   } catch(err) {
-    return done(new JsonWebTokenError('invalid token'));
+    return done(new JsonWebTokenError('jws threw an exception while decoding the token'));
   }
 
   if (!decodedToken) {
-    return done(new JsonWebTokenError('invalid token'));
+    return done(new JsonWebTokenError('jws failed to decode the token'));
   }
 
   var header = decodedToken.header;

--- a/verify.js
+++ b/verify.js
@@ -68,15 +68,10 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
 
   }
 
-  var decodedToken;
-  try {
-    decodedToken = jws.decode(jwtString);
-  } catch(err) {
-    return done(new JsonWebTokenError('jws threw an exception while decoding the token'));
-  }
+  var decodedToken = jws.decode(jwtString);
 
   if (!decodedToken) {
-    return done(new JsonWebTokenError('jws failed to decode the token'));
+    return done(new JsonWebTokenError('invalid token'));
   }
 
   var header = decodedToken.header;

--- a/verify.js
+++ b/verify.js
@@ -68,7 +68,12 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
 
   }
 
-  var decodedToken = jws.decode(jwtString);
+  var decodedToken;
+  try {
+    decodedToken = jws.decode(jwtString);
+  } catch(err) {
+    return done(err);
+  }
 
   if (!decodedToken) {
     return done(new JsonWebTokenError('invalid token'));


### PR DESCRIPTION
jws.decode() never throws an error. At least, in its current version. However, if it were to throw an exception, the diagnostics would be indistinguishable from a soft failure to decode a token. I had an extra trailing space on my JWT and it took me some additional debugging work to trace the actual root cause because the error message was not distinct.