### PR TITLE
Fix handling non string tokens

### DIFF
--- a/test/issue_304.tests.js
+++ b/test/issue_304.tests.js
@@ -1,0 +1,41 @@
+var jwt = require('../index');
+var expect = require('chai').expect;
+
+describe('issue 304 - verifying values other than strings', function() {
+
+  it('should fail with numbers', function (done) {
+    jwt.verify(123, 'foo', function (err, decoded) {
+      expect(err.name).to.equal('JsonWebTokenError');
+      done();
+    });
+  });
+
+  it('should fail with objects', function (done) {
+    jwt.verify({ foo: 'bar' }, 'biz', function (err, decoded) {
+      expect(err.name).to.equal('JsonWebTokenError');
+      done();
+    });
+  });
+
+  it('should fail with arrays', function (done) {
+    jwt.verify(['foo'], 'bar', function (err, decoded) {
+      expect(err.name).to.equal('JsonWebTokenError');
+      done();
+    });
+  });
+
+  it('should fail with functions', function (done) {
+    jwt.verify(function() {}, 'foo', function (err, decoded) {
+      expect(err.name).to.equal('JsonWebTokenError');
+      done();
+    });
+  });
+
+  it('should fail with booleans', function (done) {
+    jwt.verify(true, 'foo', function (err, decoded) {
+      expect(err.name).to.equal('JsonWebTokenError');
+      done();
+    });
+  });
+
+});

--- a/verify.js
+++ b/verify.js
@@ -38,6 +38,10 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('jwt must be provided'));
   }
 
+  if (typeof jwtString !== 'string') {
+    return done(new JsonWebTokenError('jwt must be a string'));
+  }
+
   var parts = jwtString.split('.');
 
   if (parts.length !== 3){


### PR DESCRIPTION
This PR adds handling of non string tokens, throwing a `JsonWebTokenError` error with `jwt malformed` message instead of `TypeError`.

Closes #304 