### PR TITLE
`expiresIn` and `notBefore` require milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ encoded private key for RSA and ECDSA.
 `options`:
 
 * `algorithm` (default: `HS256`)
-* `expiresIn`: expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `60`, `"2 days"`, `"10h"`, `"7d"`
-* `notBefore`: expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `60`, `"2 days"`, `"10h"`, `"7d"`
+* `expiresIn`: expressed in milliseconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `60`, `"2 days"`, `"10h"`, `"7d"`
+* `notBefore`: expressed in milliseconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `60`, `"2 days"`, `"10h"`, `"7d"`
 * `audience`
 * `issuer`
 * `jwtid`


### PR DESCRIPTION
The Readme claims the keys `expiresIn` and `notBefore require either a number of seconds or a time span.
This commit corrects to milliseconds.