### PR TITLE
Checking of nonce is essential

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -164,6 +164,12 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     }
   }
 
+  if (options.nonce) {
+    if (payload.nonce !== options.nonce) {
+      return done(new JsonWebTokenError('jwt nonce invalid. expected: ' + options.nonce));
+    }
+  }
+
   if (options.maxAge) {
     var maxAge = ms(options.maxAge);
     if (typeof payload.iat !== 'number') {


### PR DESCRIPTION
OpenID ID token is a JWT, and uses a "nonce" field, intended to be provided by the RP and echoed back in the returned JWT token, thus a piece of a JWT payload that is supposed to be checked, often. In fact, my interpretation of RFC7159 suggests that "jti" is more like a server-assigned UUID of the given token, unknown to the consumer beforehand, thus not a possible input to the verification process (or if anything, a negative input to the verification process, where the knowledge and match of a jti would mean that the token has already been "seen" and "consumed", even if the nonce would be matching)

