### PR TITLE
Reduce size of NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,11 @@
   "engines": {
     "npm": ">=1.4.28",
     "node": ">=0.12"
-  }
+  },
+  "files": [
+    "lib",
+    "decode.js",
+    "sign.js",
+    "verify.js"
+  ]
 }


### PR DESCRIPTION
This change removes the following files/directories:

- .history
- bin
- test
- .jshintrc
- .npmignore
- .travis.yml
- CHANGELOG.md

The lib directory, decode.js, sign.js and verify.js are kept explicitly, README.md, package.json, LICENSE and index.js are kept implicitly.

If you want to keep some of the above files please let me know and I update the PR.