### PR TITLE
maxAge: Fix logic with number + use seconds instead of ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ encoded public key for RSA and ECDSA.
 * `ignoreNotBefore`...
 * `subject`: if you want to check subject (`sub`), provide a value here
 * `clockTolerance`: number of seconds to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers
-* `maxAge`: the maximum allowed age for tokens to still be valid. Currently it is expressed in milliseconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `1000`, `"2 days"`, `"10h"`, `"7d"`. **We advise against using milliseconds precision, though, since JWTs can only contain seconds. The maximum precision might be reduced to seconds in the future.**
-* `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons (also against `maxAge`, so our advise is to avoid using `clockTimestamp` and a `maxAge` in milliseconds together)
+* `maxAge`: the maximum allowed age for tokens to still be valid. It is expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). Eg: `1000`, `"2 days"`, `"10h"`, `"7d"`.
+* `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons.
 
 
 ```js

--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -115,7 +115,7 @@ describe('verify', function() {
 
     describe('option: maxAge', function () {
 
-      ['3s', 3].forEach(function(maxAge) {
+      [String('3s'), '3s', 3].forEach(function(maxAge) {
         it(`should error for claims issued before a certain timespan (${typeof maxAge} type)`, function (done) {
           clock = sinon.useFakeTimers(1437018587000); // iat + 5s, exp - 5s
           var options = {algorithms: ['HS256'], maxAge: maxAge};
@@ -131,7 +131,7 @@ describe('verify', function() {
         });
       });
 
-      ['5s', 5].forEach(function (maxAge) {
+      [String('5s'), '5s', 5].forEach(function (maxAge) {
         it(`should not error for claims issued before a certain timespan but still inside clockTolerance timespan (${typeof maxAge} type)`, function (done) {
           clock = sinon.useFakeTimers(1437018587500); // iat + 5.5s, exp - 4.5s
           var options = {algorithms: ['HS256'], maxAge: maxAge, clockTolerance: 1 };
@@ -144,7 +144,7 @@ describe('verify', function() {
         });
       });
 
-      ['6s', 6].forEach(function (maxAge) {
+      [String('6s'), '6s', 6].forEach(function (maxAge) {
         it(`should not error if within maxAge timespan (${typeof maxAge} type)`, function (done) {
           clock = sinon.useFakeTimers(1437018587500);// iat + 5.5s, exp - 4.5s
           var options = {algorithms: ['HS256'], maxAge: maxAge};
@@ -157,7 +157,7 @@ describe('verify', function() {
         });
       });
 
-      ['8s', 8].forEach(function (maxAge) {
+      [String('8s'), '8s', 8].forEach(function (maxAge) {
         it(`can be more restrictive than expiration (${typeof maxAge} type)`, function (done) {
           clock = sinon.useFakeTimers(1437018591900); // iat + 9.9s, exp - 0.1s
           var options = {algorithms: ['HS256'], maxAge: maxAge };
@@ -173,7 +173,7 @@ describe('verify', function() {
         });
       });
 
-      ['12s', 12].forEach(function (maxAge) {
+      [String('12s'), '12s', 12].forEach(function (maxAge) {
         it(`cannot be more permissive than expiration (${typeof maxAge} type)`, function (done) {
           clock = sinon.useFakeTimers(1437018593000); // iat + 11s, exp + 1s
           var options = {algorithms: ['HS256'], maxAge: '12s'};
@@ -184,6 +184,20 @@ describe('verify', function() {
             assert.equal(err.message, 'jwt expired');
             assert.equal(err.expiredAt.constructor.name, 'Date');
             assert.equal(Number(err.expiredAt), 1437018592000);
+            assert.isUndefined(p);
+            done();
+          });
+        });
+      });
+
+      [new String('1s'), 'no-timespan-string'].forEach(function (maxAge){
+        it(`should error if maxAge is specified with a wrong string format/type (value: ${maxAge}, type: ${typeof maxAge})`, function (done) {
+          clock = sinon.useFakeTimers(1437018587000); // iat + 5s, exp - 5s
+          var options = { algorithms: ['HS256'], maxAge: maxAge };
+
+          jwt.verify(token, key, options, function (err, p) {
+            assert.equal(err.name, 'JsonWebTokenError');
+            assert.equal(err.message, '"maxAge" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60');
             assert.isUndefined(p);
             done();
           });
@@ -201,6 +215,7 @@ describe('verify', function() {
           done();
         });
       });
+
     });
 
     describe('option: clockTimestamp', function () {

--- a/verify.js
+++ b/verify.js
@@ -170,6 +170,9 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     }
 
     var maxAgeTimestamp = timespan(options.maxAge, payload.iat);
+    if (typeof maxAgeTimestamp === 'undefined') {
+      return done(new JsonWebTokenError('"maxAge" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60'));
+    }
     if (clockTimestamp >= maxAgeTimestamp + (options.clockTolerance || 0)) {
       return done(new TokenExpiredError('maxAge exceeded', new Date(maxAgeTimestamp * 1000)));
     }


### PR DESCRIPTION
Fixes [#346](https://github.com/auth0/node-jsonwebtoken/issues/346)
Fixes [#273](https://github.com/auth0/node-jsonwebtoken/issues/273).

Since this will expect seconds to be used (even using string type), I mark it for `next-major`.