### PR TITLE
document keyid as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ encoded private key for RSA and ECDSA. In case of a private key with passphrase 
 * `subject`
 * `noTimestamp`
 * `header`
+* `keyid`
 
 If `payload` is not a buffer or a string, it will be coerced into a string using `JSON.stringify`.
 


### PR DESCRIPTION
The keyid (`kid`) can be passed as an option to `sign()`, but it's not documented. 
https://github.com/auth0/node-jsonwebtoken/blob/master/sign.js#L59