### PR TITLE
docs: verifying with base64 encoded secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ jwt.sign({
 `secretOrPublicKey` is a string or buffer containing either the secret for HMAC algorithms, or the PEM
 encoded public key for RSA and ECDSA.
 
+As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues/208#issuecomment-231861138), there are other libraries that expect base64 encoded secrets (random bytes encoded using base64), if that is your case you can pass `new Buffer(secret, 'base64')`, by doing this the secret will be decoded using base64 and the token verification will use the original random bytes.
+
 `options`
 
 * `algorithms`: List of strings with the names of the allowed algorithms. For instance, `["HS256", "HS384"]`.


### PR DESCRIPTION
Closes https://github.com/auth0/node-jsonwebtoken/issues/208