### PR TITLE
sign: add check to be sure secret has a value

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -66,6 +66,9 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     throw err;
   }
 
+  if (!secretOrPrivateKey) {
+    return failure(new Error('secretOrPrivateKey must have a value'));
+  }
 
   if (typeof payload === 'undefined') {
     return failure(new Error('payload is required'));

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -63,5 +63,19 @@ describe('signing a token asynchronously', function() {
         done();
       });
     });
+
+    describe('secret must have a value', function(){
+      [undefined, '', 0].forEach(function(secret){
+        it('should return an error if the secret is falsy: ' + (typeof secret === 'string' ? '(empty string)' : secret), function(done) {
+        // This is needed since jws will not answer for falsy secrets
+          jwt.sign('string', secret, {}, function(err, token) {
+            expect(err).to.be.exist();
+            expect(err.message).to.equal('secretOrPrivateKey must have a value');
+            expect(token).to.not.exist;
+            done();
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
Lately there are more people raising this, not big deal but it can be weird and create confusion. We fix it in our layer, since the [bug in JWS is still open](https://github.com/brianloveswords/node-jws/issues/62).

In case of sync call, with current master code this error is returned: `TypeError: secret must be a string or buffer`.
With this PR both will return the same error `Error: secretOrPrivateKey must have a value`, I don't think the change would break anyone, because if someone got that error their integration would not be working at all.

Fixes: https://github.com/auth0/node-jsonwebtoken/issues/286
Fixes: https://github.com/auth0/node-jsonwebtoken/issues/373