### PR TITLE
Fix for #381. Set secret string before using jws when alg is none

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -67,7 +67,11 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
   }
 
   if (!secretOrPrivateKey) {
-    return failure(new Error('secretOrPrivateKey must have a value'));
+    if (options.algorithm === 'none') {
+      secretOrPrivateKey = 'Fix for https://github.com/auth0/node-jsonwebtoken/issues/381';
+    } else {
+      return failure(new Error('secretOrPrivateKey must have a value'));
+    }
   }
 
   if (typeof payload === 'undefined') {

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -33,7 +33,7 @@ describe('signing a token asynchronously', function() {
     });
 
     it('should work with none algorithm where secret is set', function(done) {
-      jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
+      jwt.sign({ foo: 'bar' }, 'secret', { algorithm: 'none' }, function(err, token) {
         expect(token).to.be.a('string');
         expect(token.split('.')).to.have.length(3);
         done();

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -32,6 +32,22 @@ describe('signing a token asynchronously', function() {
       });
     });
 
+    it('should work with none algorithm where secret is set', function(done) {
+      jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
+        expect(token).to.be.a('string');
+        expect(token.split('.')).to.have.length(3);
+        done();
+      });
+    });
+
+    it('should work with none algorithm where secret is falsy', function(done) {
+      jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
+        expect(token).to.be.a('string');
+        expect(token.split('.')).to.have.length(3);
+        done();
+      });
+    });
+
     it('should return error when secret is not a cert for RS256', function(done) {
       //this throw an error because the secret is not a cert and RS256 requires a cert.
       jwt.sign({ foo: 'bar' }, secret, { algorithm: 'RS256' }, function (err) {
@@ -66,7 +82,7 @@ describe('signing a token asynchronously', function() {
 
     describe('secret must have a value', function(){
       [undefined, '', 0].forEach(function(secret){
-        it('should return an error if the secret is falsy: ' + (typeof secret === 'string' ? '(empty string)' : secret), function(done) {
+        it('should return an error if the secret is falsy and algorithm is not set to none: ' + (typeof secret === 'string' ? '(empty string)' : secret), function(done) {
         // This is needed since jws will not answer for falsy secrets
           jwt.sign('string', secret, {}, function(err, token) {
             expect(err).to.be.exist();


### PR DESCRIPTION
Fix for https://github.com/auth0/node-jsonwebtoken/issues/381.
- When secret is Falsy, but algorithm is set to none, make secret a non zero length string before using jws.sign()/createSign()
- Added 2 unit tests