### PR TITLE
Fix breaking change on 7.4.2 for empty secret + "none" algorithm (sync code style)

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -67,7 +67,11 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
   }
 
   if (!secretOrPrivateKey) {
-    return failure(new Error('secretOrPrivateKey must have a value'));
+    if (options.algorithm === 'none') {
+      secretOrPrivateKey = 'Fix for https://github.com/auth0/node-jsonwebtoken/issues/381';
+    } else {
+      return failure(new Error('secretOrPrivateKey must have a value'));
+    }
   }
 
   if (typeof payload === 'undefined') {

--- a/sign.js
+++ b/sign.js
@@ -66,12 +66,8 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     throw err;
   }
 
-  if (!secretOrPrivateKey) {
-    if (options.algorithm === 'none') {
-      secretOrPrivateKey = 'Fix for https://github.com/auth0/node-jsonwebtoken/issues/381';
-    } else {
-      return failure(new Error('secretOrPrivateKey must have a value'));
-    }
+  if (!secretOrPrivateKey && options.algorithm !== 'none') {
+    return failure(new Error('secretOrPrivateKey must have a value'));
   }
 
   if (typeof payload === 'undefined') {

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -40,7 +40,9 @@ describe('signing a token asynchronously', function() {
       });
     });
 
-    it('should work with none algorithm where secret is falsy', function(done) {
+    //Known bug: https://github.com/brianloveswords/node-jws/issues/62
+    //If you need this use case, you need to go for the non-callback-ish code style.
+    it.skip('should work with none algorithm where secret is falsy', function(done) {
       jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
         expect(token).to.be.a('string');
         expect(token.split('.')).to.have.length(3);

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -33,7 +33,7 @@ describe('signing a token asynchronously', function() {
     });
 
     it('should work with none algorithm where secret is set', function(done) {
-      jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
+      jwt.sign({ foo: 'bar' }, 'secret', { algorithm: 'none' }, function(err, token) {
         expect(token).to.be.a('string');
         expect(token.split('.')).to.have.length(3);
         done();

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -32,6 +32,22 @@ describe('signing a token asynchronously', function() {
       });
     });
 
+    it('should work with none algorithm where secret is set', function(done) {
+      jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
+        expect(token).to.be.a('string');
+        expect(token.split('.')).to.have.length(3);
+        done();
+      });
+    });
+
+    it('should work with none algorithm where secret is falsy', function(done) {
+      jwt.sign({ foo: 'bar' }, undefined, { algorithm: 'none' }, function(err, token) {
+        expect(token).to.be.a('string');
+        expect(token.split('.')).to.have.length(3);
+        done();
+      });
+    });
+
     it('should return error when secret is not a cert for RS256', function(done) {
       //this throw an error because the secret is not a cert and RS256 requires a cert.
       jwt.sign({ foo: 'bar' }, secret, { algorithm: 'RS256' }, function (err) {
@@ -66,7 +82,7 @@ describe('signing a token asynchronously', function() {
 
     describe('secret must have a value', function(){
       [undefined, '', 0].forEach(function(secret){
-        it('should return an error if the secret is falsy: ' + (typeof secret === 'string' ? '(empty string)' : secret), function(done) {
+        it('should return an error if the secret is falsy and algorithm is not set to none: ' + (typeof secret === 'string' ? '(empty string)' : secret), function(done) {
         // This is needed since jws will not answer for falsy secrets
           jwt.sign('string', secret, {}, function(err, token) {
             expect(err).to.be.exist();

--- a/test/jwt.hs.tests.js
+++ b/test/jwt.hs.tests.js
@@ -51,6 +51,16 @@ describe('HS256', function() {
       });
     });
 
+    it('should work with falsy secret and token not signed', function(done) {
+      var signed = jwt.sign({ foo: 'bar' }, null, { algorithm: 'none' });
+      var unsigned = signed.split('.')[0] + '.' + signed.split('.')[1] + '.';
+      jwt.verify(unsigned, 'secret', function(err, decoded) {
+        assert.isUndefined(decoded);
+        assert.isNotNull(err);
+        done();
+      });
+    });
+
     it('should throw when verifying null', function(done) {
       jwt.verify(null, 'secret', function(err, decoded) {
         assert.isUndefined(decoded);


### PR DESCRIPTION
Based on PR: https://github.com/auth0/node-jsonwebtoken/pull/382
Fix: https://github.com/auth0/node-jsonwebtoken/issues/381

It modifies @rhysmccaig approach to simply check the algorithm (`none`?) before raising an error. I think modifying the secret is hacky.

So this will reopen https://github.com/auth0/node-jsonwebtoken/issues/286 for the case of callback-ish code style and algorithm `none` (it didn't work before either). But it will solve the breaking change introduced by https://github.com/auth0/node-jsonwebtoken/pull/374