### PR TITLE
Enhance audience check to verify against regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues
 `options`
 
 * `algorithms`: List of strings with the names of the allowed algorithms. For instance, `["HS256", "HS384"]`.
-* `audience`: if you want to check audience (`aud`), provide a value here. The audience can be checked against a string, a regular expression or a list of strings and/or regular expressions.
+* `audience`: if you want to check audience (`aud`), provide a value here. The audience can be checked against a string, a regular expression or a list of strings and/or regular expressions. Eg: `"urn:foo"`, `/urn:f[o]{2}/`, `[/urn:f[o]{2}/, "urn:bar"]`
 * `issuer` (optional): string or array of strings of valid values for the `iss` field.
 * `ignoreExpiration`: if `true` do not validate the expiration of the token.
 * `ignoreNotBefore`...

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues
 `options`
 
 * `algorithms`: List of strings with the names of the allowed algorithms. For instance, `["HS256", "HS384"]`.
-* `audience`: if you want to check audience (`aud`), provide a value here
+* `audience`: if you want to check audience (`aud`), provide a value here. The audience can be checked against a string, a regular expression or a list of strings and/or regular expressions.
 * `issuer` (optional): string or array of strings of valid values for the `iss` field.
 * `ignoreExpiration`: if `true` do not validate the expiration of the token.
 * `ignoreNotBefore`...

--- a/test/jwt.asymmetric_signing.tests.js
+++ b/test/jwt.asymmetric_signing.tests.js
@@ -175,8 +175,24 @@ describe('Asymmetric Algorithms', function(){
           });
         });
 
+        it('should check audience using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: /urn:f[o]{2}/  }, function (err, decoded) {
+            assert.isNotNull(decoded);
+            assert.isNull(err);
+            done();
+          });
+        });
+
         it('should check audience in array', function (done) {
           jwt.verify(token, pub, { audience: ['urn:foo', 'urn:other'] }, function (err, decoded) {
+            assert.isNotNull(decoded);
+            assert.isNull(err);
+            done();
+          });
+        });
+
+        it('should check audience in array using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: ['urn:bar', /urn:f[o]{2}/, 'urn:other'] }, function (err, decoded) {
             assert.isNotNull(decoded);
             assert.isNull(err);
             done();
@@ -193,8 +209,18 @@ describe('Asymmetric Algorithms', function(){
           });
         });
 
+        it('should throw when invalid audience using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: /urn:bar/ }, function (err, decoded) {
+            assert.isUndefined(decoded);
+            assert.isNotNull(err);
+            assert.equal(err.name, 'JsonWebTokenError');
+            assert.instanceOf(err, jwt.JsonWebTokenError);
+            done();
+          });
+        });
+
         it('should throw when invalid audience in array', function (done) {
-          jwt.verify(token, pub, { audience: ['urn:wrong', 'urn:morewrong'] }, function (err, decoded) {
+          jwt.verify(token, pub, { audience: ['urn:wrong', 'urn:morewrong', /urn:bar/] }, function (err, decoded) {
             assert.isUndefined(decoded);
             assert.isNotNull(err);
             assert.equal(err.name, 'JsonWebTokenError');
@@ -224,8 +250,24 @@ describe('Asymmetric Algorithms', function(){
           });
         });
 
+        it('should check audience using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: /urn:f[o]{2}/ }, function (err, decoded) {
+            assert.isNotNull(decoded);
+            assert.isNull(err);
+            done();
+          });
+        });
+
         it('should check audience in array', function (done) {
           jwt.verify(token, pub, { audience: ['urn:foo', 'urn:other'] }, function (err, decoded) {
+            assert.isNotNull(decoded);
+            assert.isNull(err);
+            done();
+          });
+        });
+
+        it('should check audience in array using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: ['urn:one', 'urn:other', /urn:f[o]{2}/] }, function (err, decoded) {
             assert.isNotNull(decoded);
             assert.isNull(err);
             done();
@@ -242,8 +284,28 @@ describe('Asymmetric Algorithms', function(){
           });
         });
 
+        it('should throw when invalid audience using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: /urn:wrong/ }, function (err, decoded) {
+            assert.isUndefined(decoded);
+            assert.isNotNull(err);
+            assert.equal(err.name, 'JsonWebTokenError');
+            assert.instanceOf(err, jwt.JsonWebTokenError);
+            done();
+          });
+        });
+
         it('should throw when invalid audience in array', function (done) {
           jwt.verify(token, pub, { audience: ['urn:wrong', 'urn:morewrong'] }, function (err, decoded) {
+            assert.isUndefined(decoded);
+            assert.isNotNull(err);
+            assert.equal(err.name, 'JsonWebTokenError');
+            assert.instanceOf(err, jwt.JsonWebTokenError);
+            done();
+          });
+        });
+
+        it('should throw when invalid audience in array', function (done) {
+          jwt.verify(token, pub, { audience: ['urn:wrong', 'urn:morewrong', /urn:alsowrong/] }, function (err, decoded) {
             assert.isUndefined(decoded);
             assert.isNotNull(err);
             assert.equal(err.name, 'JsonWebTokenError');
@@ -267,8 +329,18 @@ describe('Asymmetric Algorithms', function(){
           });
         });
 
+        it('should check audience using RegExp', function (done) {
+          jwt.verify(token, pub, { audience: /urn:wrong/ }, function (err, decoded) {
+            assert.isUndefined(decoded);
+            assert.isNotNull(err);
+            assert.equal(err.name, 'JsonWebTokenError');
+            assert.instanceOf(err, jwt.JsonWebTokenError);
+            done();
+          });
+        });
+
         it('should check audience in array', function (done) {
-          jwt.verify(token, pub, { audience: ['urn:wrong', 'urn:morewrong'] }, function (err, decoded) {
+          jwt.verify(token, pub, { audience: ['urn:wrong', 'urn:morewrong', /urn:alsowrong/] }, function (err, decoded) {
             assert.isUndefined(decoded);
             assert.isNotNull(err);
             assert.equal(err.name, 'JsonWebTokenError');

--- a/verify.js
+++ b/verify.js
@@ -131,7 +131,11 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     var audiences = Array.isArray(options.audience)? options.audience : [options.audience];
     var target = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
 
-    var match = target.some(function(aud) { return audiences.indexOf(aud) != -1; });
+    var match = target.some(function(targetAudience) {
+      return audiences.some(function(audience) {
+        return audience instanceof RegExp ? audience.test(targetAudience) : audience === targetAudience;
+      });
+    });
 
     if (!match)
       return done(new JsonWebTokenError('jwt audience invalid. expected: ' + audiences.join(' or ')));


### PR DESCRIPTION
The content of this pull request is to introduce the possibility to verify the audience against a regular expression.

The usage of this feature would be in a restrictive scenario where the audience needs to be verifiable against a large set of audiences because it has a parameter as part of the urn.

E.g.: Using a rest-endpoint to query all items of a specific order:
The endpoint listens to uris of the following structure: /Orders/:OrderId/Items
With the old implementation the audience could be verified against:
- a subset of the uri: '/Order/Items'
- an exhaustive list of permuatations ['/Order/1/Items', '/Order/2/Items', ... '/Order/1234/Items']

Or with the new implementation it can be verified against valid orderIds: ^\/Order\/\d{1,4}\/Items$
