### PR TITLE
Secret callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Example verify token with fetching public key from Keycloak server
 var KeyCloakCerts = require('get-keycloak-public-key');
 
 var keycloak_url = 'https://my-keycloak-server.com';
-var keycloak_realm = 'MyRealm;
+var keycloak_realm = 'MyRealm';
 var cache_ttl = 600; // 600sec = 10min
 
 var keyCloakCerts = new KeyCloakCerts(keycloak_url, keycloak_realm);

--- a/README.md
+++ b/README.md
@@ -190,62 +190,17 @@ jwt.verify(token, cert, { algorithms: ['RS256'] }, function (err, payload) {
   // if token alg != RS256,  err == invalid signature
 });
 
-```
-
-Example verify token with fetching public key from Keycloak server
-```js
-var KeyCloakCerts = require('get-keycloak-public-key');
-
-var keycloak_url = 'https://my-keycloak-server.com';
-var keycloak_realm = 'MyRealm';
-var cache_ttl = 600; // 600sec = 10min
-
-var keyCloakCerts = new KeyCloakCerts(keycloak_url, keycloak_realm);
-var key_cache = { };
-
-function keyFunc(header, callback) {
-  // Get kid
-
-  var kid = header.kid;
-  if(!kid) {
-    callback(new Error("header doesn't contain kid"));
-    return;
-  }
-
-  // Get key from cache
-
-  var cached_key = key_cache[kid] || {};
-  var key = cached_key.key;
-  var expires = cached_key.expires;
-  if(key && expires > Date.now()) {
-    callback(undefined, key);
-    return;
-  }
-
-  // Fetch from auth server
-
-  console.log("Fetching cert for kid:", kid);
-  
-  keyCloakCerts.fetch(kid)
-  .then(key => {
-    key_cache[kid] = { expires: Date.now() + cache_ttl * 1000, key };
-    callback(undefined, key);    
-  })
-  .catch(err => {
-    callback(err);
-  });
+// Verify using getKey callback
+function getKey(header, callback) {
+  // fetch secret or public key
+  const key = ...;
+  callback(null, key);
 }
 
-verify(token, keyFunc, options, function(err, decoded) {
-  if(err) {
-    console.error(err);
-  }
-  else {
-    console.log(decoded);
-  }
+verify(token, getKey, options, function(err, decoded) {
+  console.log(decoded.foo) // bar
 });
 ```
-
 
 ### jwt.decode(token [, options])
 

--- a/verify.js
+++ b/verify.js
@@ -4,7 +4,6 @@ var TokenExpiredError = require('./lib/TokenExpiredError');
 var decode            = require('./decode');
 var timespan          = require('./lib/timespan');
 var jws               = require('jws');
-var xtend             = require('xtend');
 
 module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   if ((typeof options === 'function') && !callback) {
@@ -16,8 +15,6 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     options = {};
   }
 
-  //clone this object since we are going to mutate it.
-  options = xtend(options);
   var done;
 
   if (callback) {
@@ -33,8 +30,6 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('clockTimestamp must be a number'));
   }
 
-  var clockTimestamp = options.clockTimestamp || Math.floor(Date.now() / 1000);
-
   if (!jwtString){
     return done(new JsonWebTokenError('jwt must be provided'));
   }
@@ -43,39 +38,9 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('jwt must be a string'));
   }
 
-  var parts = jwtString.split('.');
-
-  if (parts.length !== 3){
-    return done(new JsonWebTokenError('jwt malformed'));
-  }
-
-  var hasSignature = parts[2].trim() !== '';
-
-  if (!hasSignature && secretOrPublicKey){
-    return done(new JsonWebTokenError('jwt signature is required'));
-  }
-
-  if (hasSignature && !secretOrPublicKey) {
-    return done(new JsonWebTokenError('secret or public key must be provided'));
-  }
-
-  if (!hasSignature && !options.algorithms) {
-    options.algorithms = ['none'];
-  }
-
-  if (!options.algorithms) {
-    options.algorithms = ~secretOrPublicKey.toString().indexOf('BEGIN CERTIFICATE') ||
-                         ~secretOrPublicKey.toString().indexOf('BEGIN PUBLIC KEY') ?
-                          [ 'RS256','RS384','RS512','ES256','ES384','ES512' ] :
-                         ~secretOrPublicKey.toString().indexOf('BEGIN RSA PUBLIC KEY') ?
-                          [ 'RS256','RS384','RS512' ] :
-                          [ 'HS256','HS384','HS512' ];
-
-  }
-
   var decodedToken;
   try {
-    decodedToken = jws.decode(jwtString);
+    decodedToken = decode(jwtString, { complete: true });
   } catch(err) {
     return done(err);
   }
@@ -86,96 +51,138 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
 
   var header = decodedToken.header;
 
-  if (!~options.algorithms.indexOf(header.alg)) {
-    return done(new JsonWebTokenError('invalid algorithm'));
+  if(header.alg ==='none' && decodedToken.signature) {
+    return done(new JsonWebTokenError('invalid token: unsigned but signature is present'));
   }
 
-  var valid;
+  var getSecret;
 
-  try {
-    valid = jws.verify(jwtString, header.alg, secretOrPublicKey);
-  } catch (e) {
-    return done(e);
-  }
-
-  if (!valid)
-    return done(new JsonWebTokenError('invalid signature'));
-
-  var payload;
-
-  try {
-    payload = decode(jwtString);
-  } catch(err) {
-    return done(err);
-  }
-
-  if (typeof payload.nbf !== 'undefined' && !options.ignoreNotBefore) {
-    if (typeof payload.nbf !== 'number') {
-      return done(new JsonWebTokenError('invalid nbf value'));
+  if(typeof secretOrPublicKey === 'function') {
+    if(!callback) {
+      return done(new JsonWebTokenError('verify must be called asynchronous if secret or public key is provided as a callback'));
     }
-    if (payload.nbf > clockTimestamp + (options.clockTolerance || 0)) {
-      return done(new NotBeforeError('jwt not active', new Date(payload.nbf * 1000)));
-    }
+
+    getSecret = secretOrPublicKey;
+  }
+  else {
+    getSecret = function(header, callback) {
+      return callback(undefined, secretOrPublicKey);
+    };
   }
 
-  if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {
-    if (typeof payload.exp !== 'number') {
-      return done(new JsonWebTokenError('invalid exp value'));
+  return getSecret(header, function(err, secretOrPublicKey) {
+    if(err) {
+      return done(new JsonWebTokenError('error in secret or public key callback: ' + err.message));
     }
-    if (clockTimestamp >= payload.exp + (options.clockTolerance || 0)) {
-      return done(new TokenExpiredError('jwt expired', new Date(payload.exp * 1000)));
+
+    var isSigned = header.alg !== 'none';
+
+    if (!isSigned && secretOrPublicKey){
+      return done(new JsonWebTokenError('jwt must be signed if secret or public key is provided'));
     }
-  }
 
-  if (options.audience) {
-    var audiences = Array.isArray(options.audience)? options.audience : [options.audience];
-    var target = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+    if (isSigned && !secretOrPublicKey) {
+      return done(new JsonWebTokenError('jwt is signed, secret or public key must be provided'));
+    }
 
-    var match = target.some(function(targetAudience) {
-      return audiences.some(function(audience) {
-        return audience instanceof RegExp ? audience.test(targetAudience) : audience === targetAudience;
+    var algorithms = options.algorithms;
+
+    if (secretOrPublicKey && !algorithms) {
+      algorithms = ~secretOrPublicKey.toString().indexOf('BEGIN CERTIFICATE') ||
+                  ~secretOrPublicKey.toString().indexOf('BEGIN PUBLIC KEY') ?
+                  [ 'RS256','RS384','RS512','ES256','ES384','ES512' ] :
+                  ~secretOrPublicKey.toString().indexOf('BEGIN RSA PUBLIC KEY') ?
+                  [ 'RS256','RS384','RS512' ] :
+                  [ 'HS256','HS384','HS512' ];
+    }
+
+    if (!algorithms || !~algorithms.indexOf(header.alg)) {
+      return done(new JsonWebTokenError('invalid algorithm: ' + header.alg));
+    }
+
+    var valid;
+
+    try {
+      valid = jws.verify(jwtString, header.alg, secretOrPublicKey);
+    } catch (err) {
+      return done(err);
+    }
+
+    if (!valid) {
+      return done(new JsonWebTokenError('invalid signature'));
+    }
+
+    var payload = decodedToken.payload;
+    var clockTimestamp = options.clockTimestamp || Math.floor(Date.now() / 1000);
+
+    if (typeof payload.nbf !== 'undefined' && !options.ignoreNotBefore) {
+      if (typeof payload.nbf !== 'number') {
+        return done(new JsonWebTokenError('invalid nbf value'));
+      }
+      if (payload.nbf > clockTimestamp + (options.clockTolerance || 0)) {
+        return done(new NotBeforeError('jwt not active', new Date(payload.nbf * 1000)));
+      }
+    }
+
+    if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {
+      if (typeof payload.exp !== 'number') {
+        return done(new JsonWebTokenError('invalid exp value'));
+      }
+      if (clockTimestamp >= payload.exp + (options.clockTolerance || 0)) {
+        return done(new TokenExpiredError('jwt expired', new Date(payload.exp * 1000)));
+      }
+    }
+
+    if (options.audience) {
+      var audiences = Array.isArray(options.audience)? options.audience : [options.audience];
+      var target = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+
+      var match = target.some(function(targetAudience) {
+        return audiences.some(function(audience) {
+          return audience instanceof RegExp ? audience.test(targetAudience) : audience === targetAudience;
+        });
       });
-    });
-
-    if (!match)
-      return done(new JsonWebTokenError('jwt audience invalid. expected: ' + audiences.join(' or ')));
-  }
-
-  if (options.issuer) {
-    var invalid_issuer =
-        (typeof options.issuer === 'string' && payload.iss !== options.issuer) ||
-        (Array.isArray(options.issuer) && options.issuer.indexOf(payload.iss) === -1);
-
-    if (invalid_issuer) {
-      return done(new JsonWebTokenError('jwt issuer invalid. expected: ' + options.issuer));
-    }
-  }
-
-  if (options.subject) {
-    if (payload.sub !== options.subject) {
-      return done(new JsonWebTokenError('jwt subject invalid. expected: ' + options.subject));
-    }
-  }
-
-  if (options.jwtid) {
-    if (payload.jti !== options.jwtid) {
-      return done(new JsonWebTokenError('jwt jwtid invalid. expected: ' + options.jwtid));
-    }
-  }
-
-  if (options.maxAge) {
-    if (typeof payload.iat !== 'number') {
-      return done(new JsonWebTokenError('iat required when maxAge is specified'));
+  
+      if (!match)
+        return done(new JsonWebTokenError('jwt audience invalid. expected: ' + audiences.join(' or ')));
     }
 
-    var maxAgeTimestamp = timespan(options.maxAge, payload.iat);
-    if (typeof maxAgeTimestamp === 'undefined') {
-      return done(new JsonWebTokenError('"maxAge" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60'));
-    }
-    if (clockTimestamp >= maxAgeTimestamp + (options.clockTolerance || 0)) {
-      return done(new TokenExpiredError('maxAge exceeded', new Date(maxAgeTimestamp * 1000)));
-    }
-  }
+    if (options.issuer) {
+      var invalid_issuer =
+          (typeof options.issuer === 'string' && payload.iss !== options.issuer) ||
+          (Array.isArray(options.issuer) && options.issuer.indexOf(payload.iss) === -1);
 
-  return done(null, payload);
+      if (invalid_issuer) {
+        return done(new JsonWebTokenError('jwt issuer invalid. expected: ' + options.issuer));
+      }
+    }
+
+    if (options.subject) {
+      if (payload.sub !== options.subject) {
+        return done(new JsonWebTokenError('jwt subject invalid. expected: ' + options.subject));
+      }
+    }
+
+    if (options.jwtid) {
+      if (payload.jti !== options.jwtid) {
+        return done(new JsonWebTokenError('jwt jwtid invalid. expected: ' + options.jwtid));
+      }
+    }
+
+    if (options.maxAge) {
+      if (typeof payload.iat !== 'number') {
+        return done(new JsonWebTokenError('iat required when maxAge is specified'));
+      }
+
+      var maxAgeTimestamp = timespan(options.maxAge, payload.iat);
+      if (typeof maxAgeTimestamp === 'undefined') {
+        return done(new JsonWebTokenError('"maxAge" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60'));
+      }
+      if (clockTimestamp >= maxAgeTimestamp + (options.clockTolerance || 0)) {
+        return done(new TokenExpiredError('maxAge exceeded', new Date(maxAgeTimestamp * 1000)));
+      }
+    }
+
+    return done(null, payload);
+  });
 };

--- a/verify.js
+++ b/verify.js
@@ -66,7 +66,7 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   }
   else {
     getSecret = function(header, callback) {
-      return callback(undefined, secretOrPublicKey);
+      return callback(null, secretOrPublicKey);
     };
   }
 


### PR DESCRIPTION
Added features
* verify's secretOrToken parameter can now be a callback function, see updated README.md for details
* hardended checks for unsigned jwt, must now explicitly add ['none'] in algorithms to pass
* updated tests and readme

Performance improvements
* removed need to clone options object
* merged two decodes into one

See issue #406
