### PR TITLE
Bump ms version to add support for negative numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.once": "^4.0.0",
-    "ms": "^2.0.0",
+    "ms": "^2.1.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## What

[`zeit/ms@2.1.1`](https://github.com/zeit/ms) added full support for negative numbers, but the package is set to `zeit/ms@2.0.0`. This can be useful when defining a `nbf` value with `zeit/ms`, ie. `nbf = '-30m'`.

Due to npm's dependency de-duping this can sometimes result in this library using version `zeit/ms@2.0.0` instead of `zeit/ms@2.1.1` resulting in invalid results. In my case [`visionmedia/debug`](https://github.com/visionmedia/debug) had their version on `zeit/ms` pinned to `2.0.0`.

This PR bumps the version to `zeit/ms@2.1.1` to ensure that negative numbers in `zeit/ms` format work as expected.

## Dedupe Example

```
$ npm show ms version
2.1.1

$ npm list ms
@org/auth-lib@1.0.0 /Users/mitmaro/code/org/auth-lib
├─┬ debug@3.1.0
│ └── ms@2.0.0
└─┬ jsonwebtoken@8.1.0
  └── ms@2.0.0  deduped
```