### PR TITLE
Clarify in README that buffer/string payloads must be JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ npm install jsonwebtoken
 
 (Synchronous) Returns the JsonWebToken as string
 
-`payload` could be an object literal, buffer or string. *Please note that* `exp` is only set if the payload is an object literal.
+`payload` could be an object literal, buffer or string representing valid JSON. *Please note that* `exp` is only set if the payload is an object literal. Buffer or string payloads are not checked for JSON validity.
 
 `secretOrPrivateKey` is a string, buffer, or object containing either the secret for HMAC algorithms or the PEM
 encoded private key for RSA and ECDSA. In case of a private key with passphrase an object `{ key, passphrase }` can be used (based on [crypto documentation](https://nodejs.org/api/crypto.html#crypto_sign_sign_private_key_output_format)), in this case be sure you pass the `algorithm` option.


### PR DESCRIPTION
It does kinda go without saying that JWTs (_JSON_ Web Tokens) need to contain JSON but it's worth mentioning that signing doesn't check your payload.  In some unit tests I was writing where the payload was a dummy (non-JSON parsable) string, JWTs were being signed okay but they're not valid according to the spec, which caused decoding of the JWTs to later fail.