### PR TITLE
Check payload is not null when decoded.

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -10,7 +10,7 @@ module.exports = function (jwt, options) {
   if(typeof payload === 'string') {
     try {
       var obj = JSON.parse(payload);
-      if(typeof obj === 'object') {
+      if(obj && typeof obj === 'object') {
         payload = obj;
       }
     } catch (e) { }


### PR DESCRIPTION
Fixed "Cannot read property 'nbf' of null" fixes #430 