### PR TITLE
xtend stomps, cannot be used as a cloning function

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,15 +20,16 @@
   },
   "dependencies": {
     "jws": "^3.1.4",
+    "lodash.clone": "^4.5.0",
     "lodash.includes": "^4.3.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isinteger": "^4.0.4",
     "lodash.isnumber": "^3.0.3",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
+    "lodash.merge": "^4.6.1",
     "lodash.once": "^4.0.0",
-    "ms": "^2.1.1",
-    "xtend": "^4.0.1"
+    "ms": "^2.1.1"
   },
   "devDependencies": {
     "atob": "^1.1.2",

--- a/sign.js
+++ b/sign.js
@@ -1,5 +1,4 @@
 var timespan = require('./lib/timespan');
-var xtend = require('xtend');
 var jws = require('jws');
 var includes = require('lodash.includes');
 var isBoolean = require('lodash.isboolean');
@@ -8,6 +7,8 @@ var isNumber = require('lodash.isnumber');
 var isPlainObject = require('lodash.isplainobject');
 var isString = require('lodash.isstring');
 var once = require('lodash.once');
+var merge = require('lodash.merge');
+var clone = require('lodash.clone');
 
 var sign_options_schema = {
   expiresIn: { isValid: function(value) { return isInteger(value) || isString(value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },
@@ -84,7 +85,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
   var isObjectPayload = typeof payload === 'object' &&
                         !Buffer.isBuffer(payload);
 
-  var header = xtend({
+  var header = merge({
     alg: options.algorithm || 'HS256',
     typ: isObjectPayload ? 'JWT' : undefined,
     kid: options.keyid
@@ -110,7 +111,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     catch (error) {
       return failure(error);
     }
-    payload = xtend(payload);
+    payload = clone(payload);
   } else {
     var invalid_options = options_for_objects.filter(function (opt) {
       return typeof options[opt] !== 'undefined';

--- a/verify.js
+++ b/verify.js
@@ -4,7 +4,7 @@ var TokenExpiredError = require('./lib/TokenExpiredError');
 var decode            = require('./decode');
 var timespan          = require('./lib/timespan');
 var jws               = require('jws');
-var xtend             = require('xtend');
+var clone             = require('lodash.clone');
 
 module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   if ((typeof options === 'function') && !callback) {
@@ -17,7 +17,7 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   }
 
   //clone this object since we are going to mutate it.
-  options = xtend(options);
+  options = clone(options);
   var done;
 
   if (callback) {


### PR DESCRIPTION
Recently I discovered that jsonwebtoken was stomping all over the verify options. It turns out xtend is not safe to  use as a clone function. It does not create a new object that is safe for mutating.

This PR replaces xtend with lodash.merge and lodash.clone.

verify.js now uses clone to get a new object that doesn't stomp.
sign.js now uses merge instead of extend to merge options together.