### PR TITLE
Replace isPlainObject with isObjectLike

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lodash.isinteger": "^4.0.4",
     "lodash.isnumber": "^3.0.3",
     "lodash.isobjectlike": "^4.0.0",
-    "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.once": "^4.0.0",
     "ms": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lodash.isboolean": "^3.0.3",
     "lodash.isinteger": "^4.0.4",
     "lodash.isnumber": "^3.0.3",
+    "lodash.isobjectlike": "^4.0.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.once": "^4.0.0",

--- a/sign.js
+++ b/sign.js
@@ -6,6 +6,7 @@ var isBoolean = require('lodash.isboolean');
 var isInteger = require('lodash.isinteger');
 var isNumber = require('lodash.isnumber');
 var isPlainObject = require('lodash.isplainobject');
+var isObjectLike = require('lodash.isobjectlike');
 var isString = require('lodash.isstring');
 var once = require('lodash.once');
 
@@ -31,8 +32,8 @@ var registered_claims_schema = {
 };
 
 function validate(schema, allowUnknown, object, parameterName) {
-  if (!isPlainObject(object)) {
-    throw new Error('Expected "' + parameterName + '" to be a plain object.');
+  if (!isObjectLike(object)) {
+    throw new Error('Expected "' + parameterName + '" to be object like.');
   }
   Object.keys(object)
     .forEach(function(key) {

--- a/sign.js
+++ b/sign.js
@@ -5,7 +5,6 @@ var includes = require('lodash.includes');
 var isBoolean = require('lodash.isboolean');
 var isInteger = require('lodash.isinteger');
 var isNumber = require('lodash.isnumber');
-var isPlainObject = require('lodash.isplainobject');
 var isObjectLike = require('lodash.isobjectlike');
 var isString = require('lodash.isstring');
 var once = require('lodash.once');
@@ -15,7 +14,7 @@ var sign_options_schema = {
   notBefore: { isValid: function(value) { return isInteger(value) || isString(value); }, message: '"notBefore" should be a number of seconds or string representing a timespan' },
   audience: { isValid: function(value) { return isString(value) || Array.isArray(value); }, message: '"audience" must be a string or array' },
   algorithm: { isValid: includes.bind(null, ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none']), message: '"algorithm" must be a valid string enum value' },
-  header: { isValid: isPlainObject, message: '"header" must be an object' },
+  header: { isValid: isObjectLike, message: '"header" must be an object' },
   encoding: { isValid: isString, message: '"encoding" must be a string' },
   issuer: { isValid: isString, message: '"issuer" must be a string' },
   subject: { isValid: isString, message: '"subject" must be a string' },


### PR DESCRIPTION
This pull request replaces the use of lodash.isPlainObject with lodash.isObjectLike. There seems to be some  reported issues since the change to the object validation to use lodash. We were running into issues using node-postgres which returns an anonymous object as query results such as:
```
const user = await knex('user')
  .first('id', 'name', 'email')
  .where({ 'email: email });
```
Which would return something like this:
```
anonymous {
  id: '1234',
  name: 'John Doe'
}
```
Which failed the isPlainObject validation but passes the isObjectLike validation.