### PR TITLE
travis ci fix for node 4 and 5 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 sudo: false
-before_install: npm i -g npm
 node_js:
   - "8"
   - "7"


### PR DESCRIPTION
`before_install` script downloads npm@6 by default now.
Probably it is not needed to enforce the installation of npm in `before_install` script, removing it.

Failure:
```
$ node --version
v4.9.1
$ npm --version
2.15.11
$ nvm --version
0.33.11
before_install
14.92s$ npm i -g npm
/home/travis/.nvm/versions/node/v4.9.1/bin/npm -> /home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm/bin/npm-cli.js
/home/travis/.nvm/versions/node/v4.9.1/bin/npx -> /home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm/bin/npx-cli.js
npm@6.0.1 /home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm
3.35s$ npm install 
/home/travis/.nvm/versions/node/v4.9.1/lib/node_modules/npm/bin/npm-cli.js:79
      let notifier = require('update-notifier')({pkg})
      ^^^
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:140:18)
    at node.js:1043:3
```