### PR TITLE
deps: jws@3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "jws": "^3.1.4",
+    "jws": "^3.1.5",
     "lodash.includes": "^4.3.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isinteger": "^4.0.4",


### PR DESCRIPTION
This sets jws@3.1.5 as base dependency version to get a security bug fixed by default.

More details in the original PR (I created this one because CI was failing in the original one and contributor had to rebase, it was taken longer than expected):
* https://github.com/auth0/node-jsonwebtoken/pull/466

Fixes: https://github.com/auth0/node-jsonwebtoken/issues/465
