### PR TITLE
Refactor tests related to subject and sub

### DIFF
--- a/test/claim-sub.tests.js
+++ b/test/claim-sub.tests.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const jwt = require('../');
+const expect = require('chai').expect;
+const util = require('util');
+
+function signWithSubject(payload, subject) {
+  const options = {algorithm: 'none'};
+  if (subject !== undefined) {
+    options.subject = subject;
+  }
+  return jwt.sign(payload, undefined, options);
+}
+
+describe('subject', function() {
+  describe('`jwt.sign` "subject" option validation', function () {
+    [
+      true,
+      false,
+      null,
+      -1,
+      0,
+      1,
+      -1.1,
+      1.1,
+      -Infinity,
+      Infinity,
+      NaN,
+      [],
+      ['foo'],
+      {},
+      {foo: 'bar'},
+    ].forEach((subject) => {
+      it(`should error with with value ${util.inspect(subject)}`, function () {
+        expect(() => signWithSubject({}, subject)).to.throw('"subject" must be a string');
+      });
+    });
+
+    // undefined needs special treatment because {} is not the same as {subject: undefined}
+    it('should error with with value undefined', function () {
+      expect(() => jwt.sign({}, undefined, {subject: undefined, algorithm: 'none'})).to.throw(
+        '"subject" must be a string'
+      );
+    });
+
+    it('should error when "sub" is in payload', function () {
+      expect(() => signWithSubject({sub: 'bar'}, 'foo')).to.throw(
+        'Bad "options.subject" option. The payload already has an "sub" property.'
+      );
+    });
+
+
+    it('should error with a string payload', function () {
+      expect(() => signWithSubject('a string payload', 'foo')).to.throw(
+        'invalid subject option for string payload'
+      );
+    });
+
+    it('should error with a Buffer payload', function () {
+      expect(() => signWithSubject(new Buffer('a Buffer payload'), 'foo')).to.throw(
+        'invalid subject option for object payload'
+      );
+    });
+  });
+
+  describe('when signing and verifying a token with "subject" option', function () {
+    it('should verify with a string "subject"', function () {
+      const token = signWithSubject({}, 'foo');
+      const decoded = jwt.decode(token);
+      const verified = jwt.verify(token, undefined, {subject: 'foo'});
+      expect(decoded).to.deep.equal(verified);
+      expect(decoded.sub).to.equal('foo');
+    });
+
+    it('should verify with a string "sub"', function () {
+      const token = signWithSubject({sub: 'foo'});
+      const decoded = jwt.decode(token);
+      const verified = jwt.verify(token, undefined, {subject: 'foo'});
+      expect(decoded).to.deep.equal(verified);
+      expect(decoded.sub).to.equal('foo');
+    });
+
+    it('should not verify "sub" if "verify.subject" option not provided', function() {
+      const token = signWithSubject({sub: 'foo'});
+      const decoded = jwt.decode(token);
+      const verified = jwt.verify(token, undefined);
+      expect(decoded).to.deep.equal(verified);
+      expect(decoded.sub).to.equal('foo');
+    });
+
+    it('should error if "sub" does not match "verify.subject" option', function() {
+      const token = signWithSubject({sub: 'foo'});
+      expect(() => jwt.verify(token, undefined, {subject: 'bar'})).to.throw(
+        jwt.JsonWebTokenError,
+        'jwt subject invalid. expected: bar'
+      );
+    });
+
+    it('should error without "sub" and with "verify.subject" option', function() {
+      const token = signWithSubject({});
+      expect(() => jwt.verify(token, undefined, {subject: 'foo'})).to.throw(
+        jwt.JsonWebTokenError,
+        'jwt subject invalid. expected: foo'
+      );
+    });
+  });
+});

--- a/test/jwt.asymmetric_signing.tests.js
+++ b/test/jwt.asymmetric_signing.tests.js
@@ -157,42 +157,6 @@ describe('Asymmetric Algorithms', function(){
         });
       });
 
-      describe('when signing a token with subject', function () {
-        var token = jwt.sign({ foo: 'bar' }, priv, { algorithm: algorithm, subject: 'subject' });
-
-        it('should check subject', function (done) {
-          jwt.verify(token, pub, { subject: 'subject' }, function (err, decoded) {
-            assert.isNotNull(decoded);
-            assert.isNull(err);
-            done();
-          });
-        });
-
-        it('should throw when invalid subject', function (done) {
-          jwt.verify(token, pub, { subject: 'wrongSubject' }, function (err, decoded) {
-            assert.isUndefined(decoded);
-            assert.isNotNull(err);
-            assert.equal(err.name, 'JsonWebTokenError');
-            assert.instanceOf(err, jwt.JsonWebTokenError);
-            done();
-          });
-        });
-      });
-
-      describe('when signing a token without subject', function () {
-        var token = jwt.sign({ foo: 'bar' }, priv, { algorithm: algorithm });
-
-        it('should check subject', function (done) {
-          jwt.verify(token, pub, { subject: 'subject' }, function (err, decoded) {
-            assert.isUndefined(decoded);
-            assert.isNotNull(err);
-            assert.equal(err.name, 'JsonWebTokenError');
-            assert.instanceOf(err, jwt.JsonWebTokenError);
-            done();
-          });
-        });
-      });
-
       describe('when signing a token with jwt id', function () {
         var token = jwt.sign({ foo: 'bar' }, priv, { algorithm: algorithm, jwtid: 'jwtid' });
 

--- a/test/schema.tests.js
+++ b/test/schema.tests.js
@@ -51,13 +51,6 @@ describe('schema', function() {
       sign({issuer: 'foo'});
     });
 
-    it('should validate subject', function () {
-      expect(function () {
-        sign({ subject: 10 });
-      }).to.throw(/"subject" must be a string/);
-      sign({subject: 'foo'});
-    });
-
     it('should validate noTimestamp', function () {
       expect(function () {
         sign({ noTimestamp: 10 });


### PR DESCRIPTION
For #492 

This change extracts all tests in the existing files related to the subject option and sub claim into a single test file. Several other tests are also added that were missing from the existing files.

I removed all references to "subject" and "sub" from the existing test files that I could find.

There seems to be only minimal validation on the subject claim. The next major version could handle adding validation to this claim.

As always, suggestions or missing tests are welcome!

#### Coverage Master

```
=============================== Coverage summary ===============================
Statements   : 97.87% ( 230/235 )
Branches     : 97.55% ( 199/204 )
Functions    : 100% ( 23/23 )
Lines        : 98.28% ( 228/232 )
================================================================================
```

#### Coverage Branch

```
=============================== Coverage summary ===============================
Statements   : 97.87% ( 230/235 )
Branches     : 97.55% ( 199/204 )
Functions    : 100% ( 23/23 )
Lines        : 98.28% ( 228/232 )
================================================================================
```