### PR TITLE
Update dependencies used for running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,13 +48,13 @@
   },
   "devDependencies": {
     "atob": "^1.1.2",
-    "chai": "^1.10.0",
+    "chai": "^4.1.2",
     "conventional-changelog": "~1.1.0",
     "cost-of-modules": "^1.0.1",
     "eslint": "^4.19.1",
-    "mocha": "^2.1.0",
+    "mocha": "^5.2.0",
     "nsp": "^2.6.2",
-    "nyc": "^11.8.0",
+    "nyc": "^11.9.0",
     "sinon": "^6.0.0"
   },
   "engines": {

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -20,14 +20,14 @@ describe('signing a token asynchronously', function() {
 
     it('should work with empty options', function (done) {
       jwt.sign({abc: 1}, "secret", {}, function (err) {
-        expect(err).to.be.null();
+        expect(err).to.be.null;
         done();
       });
     });
 
     it('should work without options object at all', function (done) {
       jwt.sign({abc: 1}, "secret", function (err) {
-        expect(err).to.be.null();
+        expect(err).to.be.null;
         done();
       });
     });
@@ -53,7 +53,7 @@ describe('signing a token asynchronously', function() {
     it('should return error when secret is not a cert for RS256', function(done) {
       //this throw an error because the secret is not a cert and RS256 requires a cert.
       jwt.sign({ foo: 'bar' }, secret, { algorithm: 'RS256' }, function (err) {
-        expect(err).to.be.ok();
+        expect(err).to.be.ok;
         done();
       });
     });
@@ -61,14 +61,14 @@ describe('signing a token asynchronously', function() {
     it('should return error on wrong arguments', function(done) {
       //this throw an error because the secret is not a cert and RS256 requires a cert.
       jwt.sign({ foo: 'bar' }, secret, { notBefore: {} }, function (err) {
-        expect(err).to.be.ok();
+        expect(err).to.be.ok;
         done();
       });
     });
 
     it('should return error on wrong arguments (2)', function(done) {
       jwt.sign('string', 'secret', {noTimestamp: true}, function (err) {
-        expect(err).to.be.ok();
+        expect(err).to.be.ok;
         expect(err).to.be.instanceof(Error);
         done();
       });
@@ -111,7 +111,7 @@ describe('signing a token asynchronously', function() {
         it('should return an error if the secret is falsy and algorithm is not set to none: ' + (typeof secret === 'string' ? '(empty string)' : secret), function(done) {
         // This is needed since jws will not answer for falsy secrets
           jwt.sign('string', secret, {}, function(err, token) {
-            expect(err).to.be.exist();
+            expect(err).to.exist;
             expect(err.message).to.equal('secretOrPrivateKey must have a value');
             expect(token).to.not.exist;
             done();


### PR DESCRIPTION
# What

Update [chai to 4.1.2](https://github.com/chaijs/chai/releases/tag/4.1.2) and mocha to the latest versions and update nyc to the latest version that supports Node 4.

## Motivation

I keep hitting minor differences with `chai@1`, with the documentation for `chai@4`. There are also numerous bug fixes and additions that we are missing out with this library. The only breaking change as it relates to this code base is the [removal of the "lint" friendly assertions](https://github.com/chaijs/chai/pull/306) in `chai@2`.

`Mocha@2` had a "fuzzy" version of the `.only` function that made running individual tests almost impossible without artificially changing the description (i.e. `describe.only('xxxx expires' //....`). There are no breaking changes that should affect the project. 
