### PR TITLE
Fixed error message when empty string passed as expiresIn or notBefore option

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -9,8 +9,8 @@ var isString = require('lodash.isstring');
 var once = require('lodash.once');
 
 var sign_options_schema = {
-  expiresIn: { isValid: function(value) { return isInteger(value) || isString(value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },
-  notBefore: { isValid: function(value) { return isInteger(value) || isString(value); }, message: '"notBefore" should be a number of seconds or string representing a timespan' },
+  expiresIn: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },
+  notBefore: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"notBefore" should be a number of seconds or string representing a timespan' },
   audience: { isValid: function(value) { return isString(value) || Array.isArray(value); }, message: '"audience" must be a string or array' },
   algorithm: { isValid: includes.bind(null, ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none']), message: '"algorithm" must be a valid string enum value' },
   header: { isValid: isPlainObject, message: '"header" must be an object' },

--- a/test/claim-exp.test.js
+++ b/test/claim-exp.test.js
@@ -29,6 +29,7 @@ describe('expires', function() {
       Infinity,
       NaN,
       ' ',
+      '',
       'invalid',
       [],
       ['foo'],
@@ -42,16 +43,6 @@ describe('expires', function() {
             expect(err).to.have.property('message')
               .match(/"expiresIn" should be a number of seconds or string representing a timespan/);
           });
-        });
-      });
-    });
-
-    it(`should error with with value ''`, function (done) {
-      signWithExpiresIn('', {}, (err) => {
-        testUtils.asyncCheck(done, () => {
-          expect(err).to.be.instanceOf(Error);
-          expect(err).to.have.property('message')
-            .match(/"expiresIn" should be a number of seconds or string representing a timespan/);
         });
       });
     });

--- a/test/claim-exp.test.js
+++ b/test/claim-exp.test.js
@@ -46,12 +46,12 @@ describe('expires', function() {
       });
     });
 
-    // TODO this should throw the same error as other invalid inputs
     it(`should error with with value ''`, function (done) {
       signWithExpiresIn('', {}, (err) => {
         testUtils.asyncCheck(done, () => {
           expect(err).to.be.instanceOf(Error);
-          expect(err).to.have.property('message', 'val is not a non-empty string or a valid number. val=""');
+          expect(err).to.have.property('message')
+            .match(/"expiresIn" should be a number of seconds or string representing a timespan/);
         });
       });
     });

--- a/test/claim-nbf.test.js
+++ b/test/claim-nbf.test.js
@@ -51,7 +51,8 @@ describe('not before', function() {
       signWithNotBefore('', {}, (err) => {
         testUtils.asyncCheck(done, () => {
           expect(err).to.be.instanceOf(Error);
-          expect(err).to.have.property('message', 'val is not a non-empty string or a valid number. val=""');
+          expect(err).to.have.property('message')
+            .match(/"notBefore" should be a number of seconds or string representing a timespan/);
         });
       });
     });

--- a/test/claim-nbf.test.js
+++ b/test/claim-nbf.test.js
@@ -28,6 +28,7 @@ describe('not before', function() {
       -Infinity,
       Infinity,
       NaN,
+      '',
       ' ',
       'invalid',
       [],
@@ -42,17 +43,6 @@ describe('not before', function() {
             expect(err).to.have.property('message')
               .match(/"notBefore" should be a number of seconds or string representing a timespan/);
           });
-        });
-      });
-    });
-
-    // TODO this should throw the same error as other invalid inputs
-    it(`should error with with value ''`, function (done) {
-      signWithNotBefore('', {}, (err) => {
-        testUtils.asyncCheck(done, () => {
-          expect(err).to.be.instanceOf(Error);
-          expect(err).to.have.property('message')
-            .match(/"notBefore" should be a number of seconds or string representing a timespan/);
         });
       });
     });


### PR DESCRIPTION
This PR fixes TODO items to change error message when empty string passed as `expiresIn` or `notBefore` options