### PR TITLE
Implement async/sync tests for the aud claim

### DIFF
--- a/test/claim-aud.test.js
+++ b/test/claim-aud.test.js
@@ -3,13 +3,19 @@
 const jwt = require('../');
 const expect = require('chai').expect;
 const util = require('util');
+const testUtils = require('./test-utils');
 
-function signWithAudience(payload, audience) {
+function signWithAudience(audience, payload, callback) {
   const options = {algorithm: 'none'};
   if (audience !== undefined) {
     options.audience = audience;
   }
-  return jwt.sign(payload, undefined, options);
+
+  testUtils.signJWTHelper(payload, 'secret', options, callback);
+}
+
+function verifyWithAudience(token, audience,  callback) {
+  testUtils.verifyJWTHelper(token, undefined, {audience}, callback);
 }
 
 describe('audience', function() {
@@ -29,247 +35,335 @@ describe('audience', function() {
       {},
       {foo: 'bar'},
     ].forEach((audience) => {
-      it(`should error with with value ${util.inspect(audience)}`, function () {
-        expect(() => signWithAudience({}, audience)).to.throw('"audience" must be a string or array');
+      it(`should error with with value ${util.inspect(audience)}`, function (done) {
+        signWithAudience(audience, {}, (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(Error);
+            expect(err).to.have.property('message', '"audience" must be a string or array');
+          });
+        });
       });
     });
 
     // undefined needs special treatment because {} is not the same as {aud: undefined}
-    it('should error with with value undefined', function () {
-      expect(() => jwt.sign({}, undefined, {audience: undefined, algorithm: 'none'})).to.throw(
-        '"audience" must be a string or array'
-      );
+    it('should error with with value undefined', function (done) {
+      testUtils.signJWTHelper({}, 'secret', {audience: undefined, algorithm: 'none'}, (err) => {
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.instanceOf(Error);
+          expect(err).to.have.property('message', '"audience" must be a string or array');
+        });
+      });
     });
 
-    it('should error when "aud" is in payload', function () {
-      expect(() => signWithAudience({aud: ''}, 'my_aud')).to.throw(
-        'Bad "options.audience" option. The payload already has an "aud" property.'
-      );
+    it('should error when "aud" is in payload', function (done) {
+      signWithAudience('my_aud', {aud: ''}, (err) => {
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.instanceOf(Error);
+          expect(err).to.have.property(
+            'message',
+            'Bad "options.audience" option. The payload already has an "aud" property.'
+          );
+        });
+      });
     });
 
-    it('should error with a string payload', function () {
-      expect(() => signWithAudience('a string payload', 'my_aud')).to.throw(
-        'invalid audience option for string payload'
-      );
+    it('should error with a string payload', function (done) {
+      signWithAudience('my_aud', 'a string payload', (err) => {
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.instanceOf(Error);
+          expect(err).to.have.property('message', 'invalid audience option for string payload');
+        });
+      });
     });
 
-    it('should error with a Buffer payload', function () {
-      expect(() => signWithAudience(new Buffer('a Buffer payload'), 'my_aud')).to.throw(
-        'invalid audience option for object payload'
-      );
+    it('should error with a Buffer payload', function (done) {
+      signWithAudience('my_aud', new Buffer('a Buffer payload'), (err) => {
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.instanceOf(Error);
+          expect(err).to.have.property('message', 'invalid audience option for object payload');
+        });
+      });
     });
   });
 
   describe('when signing and verifying a token with "audience" option', function () {
-    describe('with a string for "aud" value in payload', function () {
+    describe('with a "aud" of "urn:foo" in payload', function () {
       let token;
 
-      beforeEach(function () {
-        token = signWithAudience({}, 'urn:foo');
+      beforeEach(function (done) {
+        signWithAudience('urn:foo', {}, (err, t) => {
+          token = t;
+          done(err);
+        });
       });
 
-      it('should verify and decode without verify "audience" option', function () {
-        const decoded = jwt.decode(token);
-        const verified = jwt.verify(token, undefined);
-
-        expect(decoded).to.deep.equal(verified);
-        expect(decoded.aud).to.equal('urn:foo');
+      [
+        undefined,
+        'urn:foo',
+        /^urn:f[o]{2}$/,
+        ['urn:no_match', 'urn:foo'],
+        ['urn:no_match', /^urn:f[o]{2}$/],
+        [/^urn:no_match$/, /^urn:f[o]{2}$/],
+        [/^urn:no_match$/, 'urn:foo']
+      ].forEach((audience) =>{
+        it(`should verify and decode with verify "audience" option of ${util.inspect(audience)}`, function (done) {
+          verifyWithAudience(token, audience, (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud', 'urn:foo');
+            });
+          });
+        });
       });
 
-      it('should verify with a string "verify.audience" option', function () {
-        expect(jwt.verify(token, undefined, {
-          audience: 'urn:foo'
-        })).to.not.throw;
+      it(`should error on no match with a string verify "audience" option`, function (done) {
+        verifyWithAudience(token, 'urn:no-match', (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', `jwt audience invalid. expected: urn:no-match`);
+          });
+        });
       });
 
-      it('should verify with an array of strings "verify.audience" option', function () {
-        expect(jwt.verify(token, undefined, {
-          audience: ['urn:no_match', 'urn:foo']
-        })).to.not.throw;
+      it('should error on no match with an array of string verify "audience" option', function (done) {
+        verifyWithAudience(token, ['urn:no-match-1', 'urn:no-match-2'], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', `jwt audience invalid. expected: urn:no-match-1 or urn:no-match-2`);
+          });
+        });
       });
 
-      it('should verify with a Regex "verify.audience" option', function () {
-        expect(jwt.verify(token, undefined, {
-          audience: /^urn:f[o]{2}$/
-        })).to.not.throw;
+      it('should error on no match with a Regex verify "audience" option', function (done) {
+        verifyWithAudience(token, /^urn:no-match$/, (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', `jwt audience invalid. expected: /^urn:no-match$/`);
+          });
+        });
       });
 
-      it('should verify with an array of Regex "verify.audience" option', function () {
-        expect(jwt.verify(token, undefined, {
-          audience: [/^urn:no_match$/, /^urn:f[o]{2}$/]
-        })).to.not.throw;
+      it('should error on no match with an array of Regex verify "audience" option', function (done) {
+        verifyWithAudience(token, [/^urn:no-match-1$/, /^urn:no-match-2$/], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property(
+              'message', `jwt audience invalid. expected: /^urn:no-match-1$/ or /^urn:no-match-2$/`
+            );
+          });
+        });
       });
 
-      it('should verify with an array containing a string and a Regex "verify.audience" option', function () {
-        expect(jwt.verify(token, undefined, {
-          audience: ['urn:no_match', /^urn:f[o]{2}$/]
-        })).to.not.throw;
-      });
-
-      it('should verify with an array containing a Regex and a string "verify.audience" option', function () {
-        expect(jwt.verify(token, undefined, {
-          audience: [/^urn:no_match$/, 'urn:foo']
-        })).to.not.throw;
-      });
-
-      it('should error on no match with a string "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: 'urn:no-match'
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: urn:no-match');
-      });
-
-      it('should error on no match with an array of string "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: ['urn:no-match-1', 'urn:no-match-2']
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: urn:no-match-1 or urn:no-match-2');
-      });
-
-      it('should error on no match with a Regex "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: /^urn:no-match$/
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match$/');
-      });
-
-      it('should error on no match with an array of Regex "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: [/^urn:no-match-1$/, /^urn:no-match-2$/]
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match-1$/ or /^urn:no-match-2$/');
-      });
-
-      it('should error on no match with an array of a Regex and a string in "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: [/^urn:no-match$/, 'urn:no-match']
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match$/ or urn:no-match');
+      it('should error on no match with an array of a Regex and a string in verify "audience" option', function (done) {
+        verifyWithAudience(token, [/^urn:no-match$/, 'urn:no-match'], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property(
+              'message', `jwt audience invalid. expected: /^urn:no-match$/ or urn:no-match`
+            );
+          });
+        });
       });
     });
 
-    describe('with an array for "aud" value in payload', function () {
+    describe('with an array of ["urn:foo", "urn:bar"] for "aud" value in payload', function () {
       let token;
 
-      beforeEach(function () {
-        token = signWithAudience({}, ['urn:foo', 'urn:bar']);
+      beforeEach(function (done) {
+        signWithAudience(['urn:foo', 'urn:bar'], {}, (err, t) => {
+          token = t;
+          done(err);
+        });
       });
 
-      it('should verify and decode without verify "audience" option', function () {
-        const decoded = jwt.decode(token);
-        const verified = jwt.verify(token, undefined);
-
-        expect(decoded).to.deep.equal(verified);
-        expect(decoded.aud).to.deep.equal(['urn:foo', 'urn:bar']);
+      [
+        undefined,
+        'urn:foo',
+        /^urn:f[o]{2}$/,
+        ['urn:no_match', 'urn:foo'],
+        ['urn:no_match', /^urn:f[o]{2}$/],
+        [/^urn:no_match$/, /^urn:f[o]{2}$/],
+        [/^urn:no_match$/, 'urn:foo']
+      ].forEach((audience) =>{
+        it(`should verify and decode with verify "audience" option of ${util.inspect(audience)}`, function (done) {
+          verifyWithAudience(token, audience, (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
+        });
       });
 
-      it('should error on no match with a string "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: 'urn:no-match'
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: urn:no-match');
+      it(`should error on no match with a string verify "audience" option`, function (done) {
+        verifyWithAudience(token, 'urn:no-match', (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', `jwt audience invalid. expected: urn:no-match`);
+          });
+        });
       });
 
-      it('should error on no match with an array of string "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: ['urn:no-match-1', 'urn:no-match-2']
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: urn:no-match-1 or urn:no-match-2');
+      it('should error on no match with an array of string verify "audience" option', function (done) {
+        verifyWithAudience(token, ['urn:no-match-1', 'urn:no-match-2'], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', `jwt audience invalid. expected: urn:no-match-1 or urn:no-match-2`);
+          });
+        });
       });
 
-      it('should error on no match with a Regex "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: /^urn:no-match$/
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match$/');
+      it('should error on no match with a Regex verify "audience" option', function (done) {
+        verifyWithAudience(token, /^urn:no-match$/, (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', `jwt audience invalid. expected: /^urn:no-match$/`);
+          });
+        });
       });
 
-      it('should error on no match with an array of Regex "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: [/^urn:no-match-1$/, /^urn:no-match-2$/]
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match-1$/ or /^urn:no-match-2$/');
+      it('should error on no match with an array of Regex verify "audience" option', function (done) {
+        verifyWithAudience(token, [/^urn:no-match-1$/, /^urn:no-match-2$/], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property(
+              'message', `jwt audience invalid. expected: /^urn:no-match-1$/ or /^urn:no-match-2$/`
+            );
+          });
+        });
       });
 
-      it('should error on no match with an array of a Regex and a string in "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: [/^urn:no-match$/, 'urn:no-match']
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match$/ or urn:no-match');
+      it('should error on no match with an array of a Regex and a string in verify "audience" option', function (done) {
+        verifyWithAudience(token, [/^urn:no-match$/, 'urn:no-match'], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property(
+              'message', `jwt audience invalid. expected: /^urn:no-match$/ or urn:no-match`
+            );
+          });
+        });
       });
 
-      describe('when checking matching for both "urn:foo" and "urn:bar"', function() {
-
-        it('should verify with an array of stings "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: ['urn:foo', 'urn:bar']
-          })).to.not.throw;
+      describe('when checking for a matching on both "urn:foo" and "urn:bar"', function() {
+        it('should verify with an array of stings verify "audience" option', function (done) {
+          verifyWithAudience(token, ['urn:foo', 'urn:bar'], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with a Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: /^urn:[a-z]{3}$/
-          })).to.not.throw;
+        it('should verify with a Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, /^urn:[a-z]{3}$/, (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array of Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: [/^urn:f[o]{2}$/, /^urn:b[ar]{2}$/]
-          })).to.not.throw;
+        it('should verify with an array of Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, [/^urn:f[o]{2}$/, /^urn:b[ar]{2}$/], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
       });
 
       describe('when checking for a matching for "urn:foo"', function() {
-        it('should verify with a string "verify.audience"', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: 'urn:foo'
-          })).to.not.throw;
+        it('should verify with a string verify "audience"', function (done) {
+          verifyWithAudience(token, 'urn:foo', (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with a Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: /^urn:f[o]{2}$/
-          })).to.not.throw;
+        it('should verify with a Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, /^urn:f[o]{2}$/, (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array of Regex "verify.audience"', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: [/^urn:no-match$/, /^urn:f[o]{2}$/]
-          })).to.not.throw;
+        it('should verify with an array of Regex verify "audience"', function (done) {
+          verifyWithAudience(token, [/^urn:no-match$/, /^urn:f[o]{2}$/], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array containing a string and a Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: ['urn:no_match', /^urn:f[o]{2}$/]
-          })).to.not.throw;
+        it('should verify with an array containing a string and a Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, ['urn:no_match', /^urn:f[o]{2}$/], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array containing a Regex and a string "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: [/^urn:no-match$/, 'urn:foo']
-          })).to.not.throw;
+        it('should verify with an array containing a Regex and a string verify "audience" option', function (done) {
+          verifyWithAudience(token, [/^urn:no-match$/, 'urn:foo'], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
       });
 
       describe('when checking matching for "urn:bar"', function() {
-        it('should verify with a string "verify.audience"', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: 'urn:bar'
-          })).to.not.throw;
+        it('should verify with a string verify "audience"', function (done) {
+          verifyWithAudience(token, 'urn:bar', (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with a Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: /^urn:b[ar]{2}$/
-          })).to.not.throw;
+        it('should verify with a Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, /^urn:b[ar]{2}$/, (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array of Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: [/^urn:no-match$/, /^urn:b[ar]{2}$/]
-          })).to.not.throw;
+        it('should verify with an array of Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, [/^urn:no-match$/, /^urn:b[ar]{2}$/], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array containing a string and a Regex "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: ['urn:no_match', /^urn:b[ar]{2}$/]
-          })).to.not.throw;
+        it('should verify with an array containing a string and a Regex verify "audience" option', function (done) {
+          verifyWithAudience(token, ['urn:no_match', /^urn:b[ar]{2}$/], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
 
-        it('should verify with an array containing a Regex and a string "verify.audience" option', function () {
-          expect(jwt.verify(token, undefined, {
-            audience: [/^urn:no-match$/, 'urn:bar']
-          })).to.not.throw;
+        it('should verify with an array containing a Regex and a string verify "audience" option', function (done) {
+          verifyWithAudience(token, [/^urn:no-match$/, 'urn:bar'], (err, decoded) => {
+            testUtils.asyncCheck(done, () => {
+              expect(err).to.be.null;
+              expect(decoded).to.have.property('aud').deep.equals(['urn:foo', 'urn:bar']);
+            });
+          });
         });
       });
     });
@@ -277,46 +371,65 @@ describe('audience', function() {
     describe('without a "aud" value in payload', function () {
       let token;
 
-      beforeEach(function () {
-        token = signWithAudience({});
+      beforeEach(function (done) {
+        signWithAudience(undefined, {}, (err, t) => {
+          token = t;
+          done(err);
+        });
       });
 
-      it('should verify and decode without verify "audience" option', function () {
-        const decoded = jwt.decode(token);
-        const verified = jwt.verify(token, undefined);
-
-        expect(decoded).to.deep.equal(verified);
-        expect(decoded).to.not.have.property('aud');
+      it('should verify and decode without verify "audience" option', function (done) {
+        verifyWithAudience(token, undefined, (err, decoded) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.null;
+            expect(decoded).to.not.have.property('aud');
+          });
+        });
       });
 
-      it('should error on no match with a string "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: 'urn:no-match'
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: urn:no-match');
+      it('should error on no match with a string verify "audience" option', function (done) {
+        verifyWithAudience(token, 'urn:no-match', (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', 'jwt audience invalid. expected: urn:no-match');
+          });
+        });
       });
 
-      it('should error on no match with an array of string "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: ['urn:no-match-1', 'urn:no-match-2']
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: urn:no-match-1 or urn:no-match-2');
+      it('should error on no match with an array of string verify "audience" option', function (done) {
+        verifyWithAudience(token, ['urn:no-match-1', 'urn:no-match-2'], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', 'jwt audience invalid. expected: urn:no-match-1 or urn:no-match-2');
+          });
+        });
       });
 
-      it('should error on no match with a Regex "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: /^urn:no-match$/
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match$/');
+      it('should error on no match with a Regex verify "audience" option', function (done) {
+        verifyWithAudience(token, /^urn:no-match$/, (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', 'jwt audience invalid. expected: /^urn:no-match$/');
+          });
+        });
       });
 
-      it('should error on no match with an array of Regex "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: [/^urn:no-match-1$/, /^urn:no-match-2$/]
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match-1$/ or /^urn:no-match-2$/');
+      it('should error on no match with an array of Regex verify "audience" option', function (done) {
+        verifyWithAudience(token, [/^urn:no-match-1$/, /^urn:no-match-2$/], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', 'jwt audience invalid. expected: /^urn:no-match-1$/ or /^urn:no-match-2$/');
+          });
+        });
       });
 
-      it('should error on no match with an array of a Regex and a string in "verify.audience" option', function () {
-        expect(() => jwt.verify(token, undefined, {
-          audience: [/^urn:no-match$/, 'urn:no-match']
-        })).to.throw(jwt.JsonWebTokenError, 'jwt audience invalid. expected: /^urn:no-match$/ or urn:no-match');
+      it('should error on no match with an array of a Regex and a string in verify "audience" option', function (done) {
+        verifyWithAudience(token, [/^urn:no-match$/, 'urn:no-match'], (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', 'jwt audience invalid. expected: /^urn:no-match$/ or urn:no-match');
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
For #492 

This implements the test helpers introduced in #523 for the aud claim. I also parameterized some of the test cases in an attempt to simplify them.

#### Coverage Master
```
=============================== Coverage summary ===============================
Statements   : 97.87% ( 230/235 )
Branches     : 97.55% ( 199/204 )
Functions    : 100% ( 23/23 )
Lines        : 98.28% ( 228/232 )
================================================================================
```

#### Coverage Branch
```
=============================== Coverage summary ===============================
Statements   : 97.87% ( 230/235 )
Branches     : 97.55% ( 199/204 )
Functions    : 100% ( 23/23 )
Lines        : 98.28% ( 228/232 )
================================================================================
```