### PR TITLE
Refactor tests related to kid and keyid

### DIFF
--- a/test/header-kid.test.js
+++ b/test/header-kid.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const jwt = require('../');
+const expect = require('chai').expect;
+const util = require('util');
+const testUtils = require('./test-utils');
+
+function signWithKeyId(keyid, payload, callback) {
+  const options = {algorithm: 'none'};
+  if (keyid !== undefined) {
+    options.keyid = keyid;
+  }
+  testUtils.signJWTHelper(payload, 'secret', options, callback);
+}
+
+describe('keyid', function() {
+  describe('`jwt.sign` "keyid" option validation', function () {
+    [
+      true,
+      false,
+      null,
+      -1,
+      0,
+      1,
+      -1.1,
+      1.1,
+      -Infinity,
+      Infinity,
+      NaN,
+      [],
+      ['foo'],
+      {},
+      {foo: 'bar'},
+    ].forEach((keyid) => {
+      it(`should error with with value ${util.inspect(keyid)}`, function (done) {
+        signWithKeyId(keyid, {}, (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(Error);
+            expect(err).to.have.property('message', '"keyid" must be a string');
+          });
+        });
+      });
+    });
+
+    // undefined needs special treatment because {} is not the same as {keyid: undefined}
+    it('should error with with value undefined', function (done) {
+      testUtils.signJWTHelper({}, undefined, {keyid: undefined, algorithm: 'none'}, (err) => {
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.instanceOf(Error);
+          expect(err).to.have.property('message', '"keyid" must be a string');
+        });
+      });
+    });
+  });
+
+  describe('when signing a token', function () {
+    it('should not add "kid" header when "keyid" option not provided', function(done) {
+      signWithKeyId(undefined, {}, (err, token) => {
+        testUtils.asyncCheck(done, () => {
+          const decoded = jwt.decode(token, {complete: true});
+          expect(err).to.be.null;
+          expect(decoded.header).to.not.have.property('kid');
+        });
+      });
+    });
+
+    it('should add "kid" header when "keyid" option is provided and an object payload', function(done) {
+      signWithKeyId('foo', {}, (err, token) => {
+        testUtils.asyncCheck(done, () => {
+          const decoded = jwt.decode(token, {complete: true});
+          expect(err).to.be.null;
+          expect(decoded.header).to.have.property('kid', 'foo');
+        });
+      });
+    });
+
+    it('should add "kid" header when "keyid" option is provided and a Buffer payload', function(done) {
+      signWithKeyId('foo', new Buffer('a Buffer payload'), (err, token) => {
+        testUtils.asyncCheck(done, () => {
+          const decoded = jwt.decode(token, {complete: true});
+          expect(err).to.be.null;
+          expect(decoded.header).to.have.property('kid', 'foo');
+        });
+      });
+    });
+
+    it('should add "kid" header when "keyid" option is provided and a string payload', function(done) {
+      signWithKeyId('foo', 'a string payload', (err, token) => {
+        testUtils.asyncCheck(done, () => {
+          const decoded = jwt.decode(token, {complete: true});
+          expect(err).to.be.null;
+          expect(decoded.header).to.have.property('kid', 'foo');
+        });
+      });
+    });
+  });
+});

--- a/test/keyid.tests.js
+++ b/test/keyid.tests.js
@@ -1,9 +1,0 @@
-var jwt = require('../index');
-
-var claims = {"name": "doron", "age": 46};
-jwt.sign(claims, 'secret', {"keyid": "1234"}, function(err, good) {
-  console.log(jwt.decode(good, {"complete": true}).header.kid);
-  jwt.verify(good, 'secret', function(err, result) {
-    console.log(result);
-  })
-});

--- a/test/schema.tests.js
+++ b/test/schema.tests.js
@@ -57,14 +57,6 @@ describe('schema', function() {
       }).to.throw(/"noTimestamp" must be a boolean/);
       sign({noTimestamp: true});
     });
-
-    it('should validate keyid', function () {
-      expect(function () {
-        sign({ keyid: 10 });
-      }).to.throw(/"keyid" must be a string/);
-      sign({keyid: 'foo'});
-    });
-
   });
 
   describe('sign payload registered claims', function() {


### PR DESCRIPTION
Next PR for #492 

This change extracts all tests in the existing test files related to `kid` and `keyid` into a single test file. Several other tests are also added that were missing from the existing files.

All references to `keyid` and `kid` have been removed from the existing test files.

As always, suggestions or missing tests are more than welcome!

#### Coverage Master
```
=============================== Coverage summary ===============================
Statements   : 97.07% ( 232/239 )
Branches     : 97.57% ( 201/206 )
Functions    : 100% ( 23/23 )
Lines        : 97.46% ( 230/236 )
================================================================================
```

#### Coverage Branch

```
=============================== Coverage summary ===============================
Statements   : 97.07% ( 232/239 )
Branches     : 97.57% ( 201/206 )
Functions    : 100% ( 23/23 )
Lines        : 97.46% ( 230/236 )
================================================================================
```