### PR TITLE
Removing someone else's .editorconfig and ignoring it.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,0 @@
-[*]
-indent_style = space
-indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 .nyc_output
 coverage
+.editorconfig


### PR DESCRIPTION
Someone else included their editor config file by accident. Removing it and ignoring it.

Let's also try not to get into the spaces vs tabs argument again. I respect both options. 👍 