### PR TITLE
Add tests for private claims in the payload

### DIFF
--- a/test/claim-private.tests.js
+++ b/test/claim-private.tests.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const expect = require('chai').expect;
+const util = require('util');
+const testUtils = require('./test-utils');
+
+function signWithPayload(payload, callback) {
+  testUtils.signJWTHelper(payload, 'secret', {algorithm: 'none'}, callback);
+}
+
+describe('with a private claim', function() {
+  [
+    true,
+    false,
+    null,
+    -1,
+    0,
+    1,
+    -1.1,
+    1.1,
+    '',
+    'private claim',
+    'UTF8 - José',
+    [],
+    ['foo'],
+    {},
+    {foo: 'bar'},
+  ].forEach((privateClaim) => {
+    it(`should sign and verify with claim of ${util.inspect(privateClaim)}`, function (done) {
+      signWithPayload({privateClaim}, (e1, token) => {
+        testUtils.verifyJWTHelper(token, undefined, {}, (e2, decoded) => {
+          testUtils.asyncCheck(done, () => {
+            expect(e1).to.be.null;
+            expect(e2).to.be.null;
+            expect(decoded).to.have.property('privateClaim').to.deep.equal(privateClaim);
+          });
+        })
+      });
+    });
+  });
+
+  // these values JSON.stringify to null
+  [
+    -Infinity,
+    Infinity,
+    NaN,
+  ].forEach((privateClaim) => {
+    it(`should sign and verify with claim of ${util.inspect(privateClaim)}`, function (done) {
+      signWithPayload({privateClaim}, (e1, token) => {
+        testUtils.verifyJWTHelper(token, undefined, {}, (e2, decoded) => {
+          testUtils.asyncCheck(done, () => {
+            expect(e1).to.be.null;
+            expect(e2).to.be.null;
+            expect(decoded).to.have.property('privateClaim', null);
+          });
+        })
+      });
+    });
+  });
+
+  // private claims with value undefined are not added to the payload
+  it(`should sign and verify with claim of undefined`, function (done) {
+    signWithPayload({privateClaim: undefined}, (e1, token) => {
+      testUtils.verifyJWTHelper(token, undefined, {}, (e2, decoded) => {
+        testUtils.asyncCheck(done, () => {
+          expect(e1).to.be.null;
+          expect(e2).to.be.null;
+          expect(decoded).to.not.have.property('privateClaim');
+        });
+      })
+    });
+  });
+});


### PR DESCRIPTION
Another PR for #492

This change adds tests for private claims added to the payload during sign and ensures that after verifying the payload contains the expected claim. There are not currently any dedicated tests to private claims, so these test cases are new.

#### Coverage Master
```
=============================== Coverage summary ===============================
Statements   : 96.72% ( 236/244 )
Branches     : 97.21% ( 209/215 )
Functions    : 100% ( 23/23 )
Lines        : 97.1% ( 234/241 )
================================================================================
```

#### Coverage Branch

```
=============================== Coverage summary ===============================
Statements   : 96.72% ( 236/244 )
Branches     : 97.21% ( 209/215 )
Functions    : 100% ( 23/23 )
Lines        : 97.1% ( 234/241 )
================================================================================
```