### PR TITLE
Force use_strict during testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "coverage": "nyc mocha",
+    "coverage": "nyc mocha --use_strict",
     "test": "npm run lint && npm run coverage && cost-of-modules"
   },
   "repository": {

--- a/sign.js
+++ b/sign.js
@@ -140,10 +140,10 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
 
   var timestamp = payload.iat || Math.floor(Date.now() / 1000);
 
-  if (!options.noTimestamp) {
-    payload.iat = timestamp;
-  } else {
+  if (options.noTimestamp) {
     delete payload.iat;
+  } else if (isObjectPayload) {
+    payload.iat = timestamp;
   }
 
   if (typeof options.notBefore !== 'undefined') {

--- a/test/claim-iat.test.js
+++ b/test/claim-iat.test.js
@@ -248,4 +248,30 @@ describe('issue at', function() {
       });
     });
   });
+
+  describe('with string payload', function () {
+    it('should not add iat to string', function (done) {
+      const payload = 'string payload';
+      const options = {algorithm: 'none'};
+      testUtils.signJWTHelper(payload, 'secret', options, (err, token) => {
+        const decoded = jwt.decode(token);
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.null;
+          expect(decoded).to.equal(payload);
+        });
+      });
+    });
+
+    it('should not add iat to stringified object', function (done) {
+      const payload = '{}';
+      const options = {algorithm: 'none', header: {typ: 'JWT'}};
+      testUtils.signJWTHelper(payload, 'secret', options, (err, token) => {
+        const decoded = jwt.decode(token);
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.equal(null);
+          expect(JSON.stringify(decoded)).to.equal(payload);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Our project was using JS strict mode and we got errors like
```
TypeError: Cannot create property 'iat' on string
```

Enabling `--use_strict` during the mocha test revealed the culprit.