### PR TITLE
fix: ensure correct PS signing and verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "jws": "^3.2.1",
+    "jws": "^3.2.2",
     "lodash.includes": "^4.3.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isinteger": "^4.0.4",


### PR DESCRIPTION
Bumps the `jws` version to ensure correct `jwa` implementation of PS algorithms is used.

- https://github.com/brianloveswords/node-jws/issues/85
- https://github.com/brianloveswords/node-jwa/pull/34