### PR TITLE
Added option for maxExpiration in verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues
 * `clockTolerance`: number of seconds to tolerate when checking the `nbf` and `exp` claims, to deal with small clock differences among different servers
 * `maxAge`: the maximum allowed age for tokens to still be valid. It is expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms). 
   > Eg: `1000`, `"2 days"`, `"10h"`, `"7d"`. A numeric value is interpreted as a seconds count. If you use a string be sure you provide the time units (days, hours, etc), otherwise milliseconds unit is used by default (`"120"` is equal to `"120ms"`).
+* `maxExpiration`: the maximum time tokens are allowed to expire in. It is expressed in seconds or a string describing a time span [zeit/ms](https://github.com/zeit/ms).
 * `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons.
 * `nonce`: if you want to check `nonce` claim, provide a string value here. It is used on Open ID for the ID Tokens. ([Open ID implementation notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))
 

--- a/test/option-maxExpiration.test.js
+++ b/test/option-maxExpiration.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const jwt = require('..');
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const util = require('util');
+
+describe('maxExpiration option', function() {
+  let token;
+
+  let fakeClock;
+  beforeEach(function() {
+    fakeClock = sinon.useFakeTimers({now: 60000});
+    token = jwt.sign({iat: 70}, undefined, {algorithm: 'none', expiresIn: '2s'});
+  });
+
+  afterEach(function() {
+    fakeClock.uninstall();
+  });
+
+  [
+    {
+      description: 'should work with a positive string value',
+      maxExpiration: '3s',
+    },
+    {
+      description: 'should work with a positive numeric value',
+      maxExpiration: 3,
+    }
+  ].forEach((testCase) => {
+    it(testCase.description, function (done) {
+      expect(jwt.verify(token, undefined, {maxExpiration: '3s'})).to.not.throw;
+      jwt.verify(token, undefined, {maxExpiration: testCase.maxExpiration}, (err) => {
+        expect(err).to.be.null;
+        done();
+      })
+    });
+  });
+
+  [
+    {
+      description: 'should error with a negative string value',
+      maxExpiration: '-3s',
+    },
+    {
+      description: 'should error with a negative numeric value',
+      maxExpiration: -3,
+    },
+    {
+      description: 'should error with a positive value less than tokens exp',
+      maxExpiration: '1s',
+    },
+    {
+      description: 'should error with a negative value less than tokens exp',
+      maxExpiration: '-3s',
+    }
+  ].forEach((testCase) => {
+    it(testCase.description, function (done) {
+      expect(() => jwt.verify(token, undefined, {maxExpiration: testCase.maxExpiration})).to.throw(
+        jwt.JsonWebTokenError,
+        'jwt expiration is longer then the specified maxExpiration: ' + testCase.maxExpiration
+      );
+      jwt.verify(token, undefined, {maxExpiration: testCase.maxExpiration}, (err) => {
+        expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+        expect(err.message).to.equal(
+          'jwt expiration is longer then the specified maxExpiration: ' + testCase.maxExpiration
+        );
+        done();
+      })
+    });
+  });
+
+  [
+    true,
+    'invalid',
+    [],
+    ['foo'],
+    {},
+    {foo: 'bar'},
+  ].forEach((maxExpiration) => {
+    it(`should error with value ${util.inspect(maxExpiration)}`, function (done) {
+      expect(() => jwt.verify(token, undefined, {maxExpiration})).to.throw(
+        jwt.JsonWebTokenError,
+        '"maxExpiration" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60'
+      );
+      jwt.verify(token, undefined, {maxExpiration}, (err) => {
+        expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+        expect(err.message).to.equal(
+          '"maxExpiration" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60'
+        );
+        done();
+      })
+    });
+  });
+});

--- a/verify.js
+++ b/verify.js
@@ -210,6 +210,23 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
       }
     }
 
+    if (options.maxExpiration) {
+      if (typeof payload.iat !== 'number') {
+        return done(new JsonWebTokenError('iat required when maxExpiration is specified'));
+      }
+      if (typeof payload.exp !== 'number') {
+        return done(new JsonWebTokenError('exp required when maxExpiration is specified'));
+      }
+
+      var maxExpirationTimestamp = timespan(options.maxExpiration, payload.iat);
+      if (typeof maxExpirationTimestamp === 'undefined') {
+        return done(new JsonWebTokenError('"maxExpiration" should be a number of seconds or string representing a timespan eg: "1d", "20h", 60'));
+      }
+      if (payload.exp > maxExpirationTimestamp + (options.clockTolerance || 0)) {
+        return done(new TokenExpiredError('jwt expiration is longer then the specified maxExpiration: ' + options.maxExpiration));
+      }
+    }
+
     if (options.complete === true) {
       var signature = decodedToken.signature;
 


### PR DESCRIPTION
Adds the option to specify maxExpiration in the verify function.
It will require the token to include exp and iat in the payload, and exp has to be less than what is specified in maxExpiration.