### PR TITLE
refactor: node-jsonwebtoken goes on dependency diet

### DIFF
--- a/lib/psSupported.js
+++ b/lib/psSupported.js
@@ -1,3 +1,3 @@
-var semver = require('semver');
+var crypto = require('crypto');
 
-module.exports = semver.satisfies(process.version, '^6.12.0 || >=8.0.0');
+module.exports = 'constants' in crypto && 'RSA_PKCS1_PSS_PADDING' in crypto.constants && 'RSA_PSS_SALTLEN_DIGEST' in crypto.constants;

--- a/package.json
+++ b/package.json
@@ -37,15 +37,8 @@
   },
   "dependencies": {
     "jws": "^3.2.2",
-    "lodash.includes": "^4.3.0",
-    "lodash.isboolean": "^3.0.3",
-    "lodash.isinteger": "^4.0.4",
-    "lodash.isnumber": "^3.0.3",
-    "lodash.isplainobject": "^4.0.6",
-    "lodash.isstring": "^4.0.1",
     "lodash.once": "^4.0.0",
-    "ms": "^2.1.1",
-    "semver": "^5.6.0"
+    "ms": "^2.1.1"
   },
   "devDependencies": {
     "atob": "^2.1.2",

--- a/sign.js
+++ b/sign.js
@@ -1,12 +1,6 @@
 var timespan = require('./lib/timespan');
 var PS_SUPPORTED = require('./lib/psSupported');
 var jws = require('jws');
-var includes = require('lodash.includes');
-var isBoolean = require('lodash.isboolean');
-var isInteger = require('lodash.isinteger');
-var isNumber = require('lodash.isnumber');
-var isPlainObject = require('lodash.isplainobject');
-var isString = require('lodash.isstring');
 var once = require('lodash.once');
 
 var SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none']
@@ -14,11 +8,17 @@ if (PS_SUPPORTED) {
   SUPPORTED_ALGS.splice(3, 0, 'PS256', 'PS384', 'PS512');
 }
 
+const isPlainObject = function(value) { return !!value && value.constructor === Object }
+const isInteger = function(value) { return Number.isInteger(value); };
+const isString = function(value) { return typeof value === 'string'; };
+const isNumber = function(value) { return typeof value === 'number' };
+const isBoolean = function(value) { return typeof value === 'boolean' };
+
 var sign_options_schema = {
   expiresIn: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },
   notBefore: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"notBefore" should be a number of seconds or string representing a timespan' },
   audience: { isValid: function(value) { return isString(value) || Array.isArray(value); }, message: '"audience" must be a string or array' },
-  algorithm: { isValid: includes.bind(null, SUPPORTED_ALGS), message: '"algorithm" must be a valid string enum value' },
+  algorithm: { isValid: function(value) { return SUPPORTED_ALGS.indexOf(value) !== -1; }, message: '"algorithm" must be a valid string enum value' },
   header: { isValid: isPlainObject, message: '"header" must be an object' },
   encoding: { isValid: isString, message: '"encoding" must be a string' },
   issuer: { isValid: isString, message: '"issuer" must be a string' },


### PR DESCRIPTION
cc @ziluvatar just removing deps that come native in node, also `semver` - we can check for PS support by inspecting crypto constants.

Note: i'm not sold on the `lodash.isplainobject` replacement, it doesn't behave exactly the same.