### PR TITLE
Add support for checking jti claim against a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Error object:
   * 'invalid signature'
   * 'jwt audience invalid. expected: [OPTIONS AUDIENCE]'
   * 'jwt issuer invalid. expected: [OPTIONS ISSUER]'
-  * 'jwt id invalid. expected: [OPTIONS JWT ID]'
+  * 'jwt jwtid invalid. expected: [OPTIONS JWT ID]'
   * 'jwt subject invalid. expected: [OPTIONS SUBJECT]'
 
 ```js

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues
   > Eg: `1000`, `"2 days"`, `"10h"`, `"7d"`. A numeric value is interpreted as a seconds count. If you use a string be sure you provide the time units (days, hours, etc), otherwise milliseconds unit is used by default (`"120"` is equal to `"120ms"`).
 * `clockTimestamp`: the time in seconds that should be used as the current time for all necessary comparisons.
 * `nonce`: if you want to check `nonce` claim, provide a string value here. It is used on Open ID for the ID Tokens. ([Open ID implementation notes](https://openid.net/specs/openid-connect-core-1_0.html#NonceNotes))
+* `jwtid`: if you want to check `jti` claim, provide a string value or a function with signature `(jti: string, callback: (err?, isRevoked) => void) => void`. When a string is used, only JWTs that match `jwtid` option will be accepted. When a function is used, only JWTs where `isRevoked` is `false` will be accepted.
 
 
 ```js
@@ -191,10 +192,20 @@ jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer' }, function(
   // if issuer mismatch, err == invalid issuer
 });
 
-// verify jwt id
+// verify jwt id (string)
 var cert = fs.readFileSync('public.pem');  // get public key
 jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer', jwtid: 'jwtid' }, function(err, decoded) {
   // if jwt id mismatch, err == invalid jwt id
+});
+
+// verify jwt id (function)
+var cert = fs.readFileSync('public.pem');  // get public key
+var checkJti = function(jti, done) {
+  // verify jti somehow (e.g: against a black-list)
+  done(null, true);
+};
+jwt.verify(token, cert, { audience: 'urn:foo', issuer: 'urn:issuer', jwtid: checkJti }, function(err, decoded) {
+  // if jwt id check fails, err == invalid jwt id
 });
 
 // verify subject

--- a/test/claim-jti.test.js
+++ b/test/claim-jti.test.js
@@ -117,7 +117,7 @@ describe('jwtid', function() {
 
       it('should verify with "jti" in payload', function (done) {
         signWithJWTId(undefined, {jti: 'foo'}, (e1, token) => {
-          testUtils.verifyJWTHelper(token, undefined, {jetid: 'foo'}, (e2, decoded) => {
+          testUtils.verifyJWTHelper(token, undefined, {jwtid: 'foo'}, (e2, decoded) => {
             testUtils.asyncCheck(done, () => {
               expect(e1).to.be.null;
               expect(e2).to.be.null;


### PR DESCRIPTION
### Description

Updates `jwtid` verification option to support receiving a function, allowing consumers to verify `jti` claims dynamically.

This PR changes the signature of the `jwtid` option to be: `{ jwtid: string | JtiVerifier }` where `JtiVerifier` is a function with the sigunature: `(jti: string, callback: (error?: Error, isRevoked: boolean) => void) => void`. 

Additionally, this PR fixes a few typos in documentation and `jti`-related tests.

### Testing

The following snippet can be used to test the functionality:
```js
const uuid = require('uuid');
const jwt = require('jsonwebtoken');

const jti = uuid.v4();
const token = jwt.sign({ jti }, 'foobar');
const revokedTokenIds = [jti];

const checkJti = (jti, done) => { done(null, revokedTokenIds.includes(jti)); };

jwt.verify(token, 'foobar', { jwtid: checkJti }); // throws jwt invalid
```

In addition, automatic test have been added to verify `jwtid` option supports receiving a function.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
