### PR TITLE
fixes numeric expiresIn sign option by normalizing handling in timest…

### DIFF
--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -10,7 +10,7 @@ module.exports = function (time, iat) {
     }
     return Math.floor(timestamp + milliseconds / 1000);
   } else if (typeof time === 'number') {
-    return ms(timestamp + time);
+    return timestamp + (time * 1000);
   } else {
     return;
   }

--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -10,7 +10,7 @@ module.exports = function (time, iat) {
     }
     return Math.floor(timestamp + milliseconds / 1000);
   } else if (typeof time === 'number') {
-    return timestamp + time;
+    return ms(timestamp + time);
   } else {
     return;
   }


### PR DESCRIPTION
Documentation says a number of seconds before expiration can be specified in the expiresIn option of the sign() function. Nevertheless, function was handling numeric values as milliseconds. 

This commit multiplies input by 1000 to fix this issue and make the library act as documented.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [NA] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
