### PR TITLE
chore: update jws

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/auth0/node-jsonwebtoken/issues"
   },
   "dependencies": {
-    "jws": "^3.2.2",
+    "jws": "^4.0.0",
     "lodash.includes": "^4.3.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isinteger": "^4.0.4",


### PR DESCRIPTION
### Description

`jsonwebtoken` does its own JWS algorithm check which didn't suffer the flaw of the `jws`/`jwa` - it would still be nice to be on the most recent semver major line.

### References

https://github.com/brianloveswords/node-jws/compare/v3.2.2...v4.0.0
https://github.com/brianloveswords/node-jwa/compare/v1.4.1...v2.0.0