### PR TITLE
feat: expose timespan as convenience

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ module.exports = {
   decode: require('./decode'),
   verify: require('./verify'),
   sign: require('./sign'),
-  timespan: require('./timespan'),
+  timespan: require('./lib/timespan'),
   JsonWebTokenError: require('./lib/JsonWebTokenError'),
   NotBeforeError: require('./lib/NotBeforeError'),
   TokenExpiredError: require('./lib/TokenExpiredError'),

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   decode: require('./decode'),
   verify: require('./verify'),
   sign: require('./sign'),
+  timespan: require('./timespan'),
   JsonWebTokenError: require('./lib/JsonWebTokenError'),
   NotBeforeError: require('./lib/NotBeforeError'),
   TokenExpiredError: require('./lib/TokenExpiredError'),


### PR DESCRIPTION
### Description

Expose `timespan` as an utility function so as to be able to expose or return the `expiresIn` from a signed token. Just a simple helper function to not have to decode the token to determine when the token expires. As well as having access to `ms`.

For example, many web based applications only do a silent refresh of the token when receiving a 401. A more better experience is the client to know when the token will expire and proactively refresh. While it is true you can decode the token on the client but that requires another unneeded lib or another step in the flow. Ideally just pass back the expiration date with the token.

I agree there are other ways of doing this but it just seems like a very simple and valid way of ensuring the code cohesiveness.

### References

```javascript
const { sign, timespan } = require("jsonwebtoken")

exports.createAccessToken = ({ id: userId }) => {
    const exp = timespan("15m")

    return {
        token: sign({ userId, exp }, process.env.ACCESS_TOKEN_SECRET),
        expiresIn: exp
    }
}
```

### Testing

None that I am aware of.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
