### PR TITLE
Allow passing json option to verify

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -66,7 +66,7 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   var decodedToken;
 
   try {
-    decodedToken = decode(jwtString, { complete: true });
+    decodedToken = decode(jwtString, { complete: true, json: options.json });
   } catch(err) {
     return done(err);
   }


### PR DESCRIPTION
### Description

The `decode` function already accepts a `json` option, which when set to true will always try and parse the resulting payload as JSON, and throw an error if that fails.

This patch adds the same option to the `verify` function, by passing the `json` option thru to the `decode` function.

### Testing

This can be tested by passing `{ json: true }` to `verify`, with a token that has a string payload. That should throw a JSON parse error.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
