### PR TITLE
docs: add jwtid to options of jwt.verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues
   > Eg: `"urn:foo"`, `/urn:f[o]{2}/`, `[/urn:f[o]{2}/, "urn:bar"]`
 * `complete`: return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload.
 * `issuer` (optional): string or array of strings of valid values for the `iss` field.
+* `jwtid` (optional): if you want to check JWT ID (`jti`), provide a string value here.
 * `ignoreExpiration`: if `true` do not validate the expiration of the token.
 * `ignoreNotBefore`...
 * `subject`: if you want to check subject (`sub`), provide a value here


### PR DESCRIPTION
### Description

This PR updates only docs. I added `jwtid` to options of jwt.verify on README.md.
`jwtid` is implemented [here](https://github.com/auth0/node-jsonwebtoken/blob/master/verify.js#L187-L191) as one of jwt.verify options.

### References

Closes #581 

### Testing

- ~~[ ] This change adds test coverage for new/changed/fixed functionality~~ => This PR updates only docs.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
