### PR TITLE
Add mutateHeader option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ encoded private key for RSA and ECDSA. In case of a private key with passphrase 
 * `header`
 * `keyid`
 * `mutatePayload`: if true, the sign function will modify the payload object directly. This is useful if you need a raw reference to the payload after claims have been applied to it but before it has been encoded into a token.
-
+* `mutateHeader`: if false, the sign function will not modify the `options.header` by assigning with the default headers values.
 
 
 > There are no default values for `expiresIn`, `notBefore`, `audience`, `subject`, `issuer`.  These claims can also be provided in the payload directly with `exp`, `nbf`, `aud`, `sub` and `iss` respectively, but you **_can't_** include in both places.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ encoded private key for RSA and ECDSA. In case of a private key with passphrase 
 * `header`
 * `keyid`
 * `mutatePayload`: if true, the sign function will modify the payload object directly. This is useful if you need a raw reference to the payload after claims have been applied to it but before it has been encoded into a token.
-* `mutateHeader`: if false, the sign function will not modify the `options.header` by assigning with the default headers values.
+* `mutateHeader`: if false, the sign function will not modify the `options.header` by assigning with the default header values.
 
 
 > There are no default values for `expiresIn`, `notBefore`, `audience`, `subject`, `issuer`.  These claims can also be provided in the payload directly with `exp`, `nbf`, `aud`, `sub` and `iss` respectively, but you **_can't_** include in both places.

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -130,5 +130,14 @@ describe('signing a token asynchronously', function() {
         });
       });
     });
+
+    describe('when mutateHeader is set to false', function () {
+      it('should return an error if the options.header is not set', function (done) {
+        jwt.sign({ foo: 'bar' }, 'secret', { mutateHeader: false }, function (err) {
+          expect(err).to.be.instanceof(Error);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### Description

The mutateHeader option allows you to control the current assignment which occurs between `options.headers` and the default header values (alg, typ and kid). Default behaviour is unchanged since mutatePayload defaults to true.

Closes #714 