### PR TITLE
Use native Array.includes() instead of lodash.includes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,16 +17,6 @@ commands:
           command: npm test
 
 jobs:
-  node-v4:
-    docker:
-      - image: node:4
-    steps:
-      - test-nodejs
-  node-v5:
-    docker:
-      - image: node:5
-    steps:
-      - test-nodejs
   node-v6:
     docker:
       - image: node:6
@@ -61,8 +51,6 @@ jobs:
 workflows:
   node-multi-build:
     jobs:
-      - node-v4
-      - node-v5
       - node-v6
       - node-v7
       - node-v8

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "jws": "^3.2.2",
-    "lodash.includes": "^4.3.0",
     "lodash.isboolean": "^3.0.3",
     "lodash.isinteger": "^4.0.4",
     "lodash.isnumber": "^3.0.3",

--- a/sign.js
+++ b/sign.js
@@ -1,7 +1,6 @@
 var timespan = require('./lib/timespan');
 var PS_SUPPORTED = require('./lib/psSupported');
 var jws = require('jws');
-var includes = require('lodash.includes');
 var isBoolean = require('lodash.isboolean');
 var isInteger = require('lodash.isinteger');
 var isNumber = require('lodash.isnumber');
@@ -18,7 +17,7 @@ var sign_options_schema = {
   expiresIn: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },
   notBefore: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"notBefore" should be a number of seconds or string representing a timespan' },
   audience: { isValid: function(value) { return isString(value) || Array.isArray(value); }, message: '"audience" must be a string or array' },
-  algorithm: { isValid: includes.bind(null, SUPPORTED_ALGS), message: '"algorithm" must be a valid string enum value' },
+  algorithm: { isValid: function(value) { return SUPPORTED_ALGS.includes(value); }, message: '"algorithm" must be a valid string enum value' },
   header: { isValid: isPlainObject, message: '"header" must be an object' },
   encoding: { isValid: isString, message: '"encoding" must be a string' },
   issuer: { isValid: isString, message: '"issuer" must be a string' },


### PR DESCRIPTION
### Description

This PR replaces the one occurrence of `lodash.includes` with the native [Array.includes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), which has been supported in Node since v6, now End Of Lifed.

### References

For a security library,
* It's valuable to reduce the number of dependencies. This is a step towards modernizing the codebase.
* The target audience keeps their Node version current. Node v6 was released in 2016 and [EOLed more than a year ago](https://web.archive.org/web/20190317014458/https://nodejs.org/en/about/releases/). Thus the use of native Array.includes is supported by all active Node releases.

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
