### PR TITLE
Rename "invalid token" error to "jwt malformed"

### DIFF
--- a/test/jwt.hs.tests.js
+++ b/test/jwt.hs.tests.js
@@ -96,16 +96,26 @@ describe('HS256', function() {
     });
   });
 
-  describe('should fail verification gracefully with trailing space in the jwt', function() {
+  describe('should fail verification gracefully on malformed token', function() {
     var secret = 'shhhhhh';
     var token  = jwt.sign({ foo: 'bar' }, secret, { algorithm: 'HS256' });
 
-    it('should return the "invalid token" error', function(done) {
+    it('should return the "jwt malformed" error with a trailing space', function(done) {
       var malformedToken = token + ' '; // corrupt the token by adding a space
       jwt.verify(malformedToken, secret, { algorithm: 'HS256', ignoreExpiration: true }, function(err) {
         assert.isNotNull(err);
         assert.equal('JsonWebTokenError', err.name);
-        assert.equal('invalid token', err.message);
+        assert.equal('jwt malformed', err.message);
+        done();
+      });
+    });
+
+    it('should return the "jwt malformed" error with missing pieces', function(done) {
+      var malformedToken = token.split('.').slice(0, 2).join('.'); // corrupt the token by removing a section
+      jwt.verify(malformedToken, secret, { algorithm: 'HS256', ignoreExpiration: true }, function(err) {
+        assert.isNotNull(err);
+        assert.equal('JsonWebTokenError', err.name);
+        assert.equal('jwt malformed', err.message);
         done();
       });
     });

--- a/verify.js
+++ b/verify.js
@@ -72,7 +72,7 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   }
 
   if (!decodedToken) {
-    return done(new JsonWebTokenError('invalid token'));
+    return done(new JsonWebTokenError('jwt malformed'));
   }
 
   var header = decodedToken.header;


### PR DESCRIPTION
# Description

This brings the message for a token with (for example) a trailing space into line with the listed potential error messages in the README.

"invalid token" is confusing and not a listed possible error message -- is it invalid because it was corrupt, unauthorized, expired, etc.?

This also adds a test for the existing case where "jwt malformed" is returned, which was otherwise untested.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
