### PR TITLE
Make it clear that payload can not be a string when coupled with expiresIn

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -125,7 +125,12 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     });
 
     if (invalid_options.length > 0) {
-      return failure(new Error('invalid ' + invalid_options.join(',') + ' option for ' + (typeof payload ) + ' payload'));
+      const suggestions = [];
+      if(invalid_options.includes('expiresIn') && typeof payload==='string'){
+        if(suggestions.length===0) suggestions.length.push('');
+        suggestions.push('expiresIn is only valid if payload is an object).
+      }
+      return failure(new Error('invalid ' + invalid_options.join(',') + ' option for ' + (typeof payload ) + ' payload' + (suggestions.join('\n'));
     }
   }
 


### PR DESCRIPTION
It is easy for people to create this error when they try to set the payload to a string and set the expiration at the same time. 

The lack of explanation makes it seem that expiresIn is malformed. Giving some suggestion in this case would be helpful.
