### PR TITLE
Verify accepts 'Bearer ' schema if passing an HTTP authorization header.

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -57,7 +57,13 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('jwt must be a string'));
   }
 
-  var parts = jwtString.split('.');
+  var parts;
+
+  if (jwtString.includes('Bearer ')) {
+    parts = jwtString.replace('Bearer ', '').split('.');
+  } else {
+    parts = jwtString.split('.');
+  }
 
   if (parts.length !== 3){
     return done(new JsonWebTokenError('jwt malformed'));


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
 
Handle if a user passes an HTTP auth header to verify(). In the format "Bearer <token>" 

> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.

No breaking changes. verify() accepts the HTTP auth header in the format "Bearer <token>".

> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
https://stackoverflow.com/questions/50284841/how-to-extract-token-string-from-bearer-token/50285194

> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

All existing tests should pass

> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
