### PR TITLE
docs: fix spelling in README.md: Peak -> Peek

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ jwt.verify(token, getKey, options, function(err, decoded) {
 ```
 
 <details>
-<summary><em></em>Need to peak into a JWT without verifying it? (Click to expand)</summary>
+<summary><em></em>Need to peek into a JWT without verifying it? (Click to expand)</summary>
 
 ### jwt.decode(token [, options])
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fix simple misspelling of `peek` in the README.md. You peek inside a token.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
