### PR TITLE
docs: document "invalid token" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,8 @@ Error object:
 
 * name: 'JsonWebTokenError'
 * message:
-  * 'jwt malformed'
+  * 'invalid token' - the header or payload could not be parsed
+  * 'jwt malformed' - the token does not have three components (delimited by a `.`)
   * 'jwt signature is required'
   * 'invalid signature'
   * 'jwt audience invalid. expected: [OPTIONS AUDIENCE]'


### PR DESCRIPTION
### Description

Adds `'invalid token'` to the list of error messages and explains the difference between that and `'jwt malformed'`

### References

https://github.com/auth0/node-jsonwebtoken/issues/768
