### PR TITLE
Remove node version checks

### DIFF
--- a/lib/psSupported.js
+++ b/lib/psSupported.js
@@ -1,3 +1,0 @@
-var semver = require('semver');
-
-module.exports = semver.satisfies(process.version, '^6.12.0 || >=8.0.0');

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.once": "^4.0.0",
-    "ms": "^2.1.1",
-    "semver": "^5.6.0"
+    "ms": "^2.1.1"
   },
   "devDependencies": {
     "atob": "^2.1.2",
@@ -60,7 +59,7 @@
   },
   "engines": {
     "npm": ">=1.4.28",
-    "node": ">=4"
+    "node": ">=8"
   },
   "files": [
     "lib",

--- a/sign.js
+++ b/sign.js
@@ -1,5 +1,4 @@
 var timespan = require('./lib/timespan');
-var PS_SUPPORTED = require('./lib/psSupported');
 var jws = require('jws');
 var includes = require('lodash.includes');
 var isBoolean = require('lodash.isboolean');
@@ -9,10 +8,7 @@ var isPlainObject = require('lodash.isplainobject');
 var isString = require('lodash.isstring');
 var once = require('lodash.once');
 
-var SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none'];
-if (PS_SUPPORTED) {
-  SUPPORTED_ALGS.splice(3, 0, 'PS256', 'PS384', 'PS512');
-}
+var SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none'];
 
 var sign_options_schema = {
   expiresIn: { isValid: function(value) { return isInteger(value) || (isString(value) && value); }, message: '"expiresIn" should be a number of seconds or string representing a timespan' },

--- a/test/async_sign.tests.js
+++ b/test/async_sign.tests.js
@@ -1,7 +1,6 @@
 var jwt = require('../index');
 var expect = require('chai').expect;
 var jws = require('jws');
-var PS_SUPPORTED = require('../lib/psSupported');
 
 describe('signing a token asynchronously', function() {
 
@@ -59,15 +58,13 @@ describe('signing a token asynchronously', function() {
       });
     });
 
-    if (PS_SUPPORTED) {
-      it('should return error when secret is not a cert for PS256', function(done) {
-        //this throw an error because the secret is not a cert and PS256 requires a cert.
-        jwt.sign({ foo: 'bar' }, secret, { algorithm: 'PS256' }, function (err) {
-          expect(err).to.be.ok;
-          done();
-        });
+    it('should return error when secret is not a cert for PS256', function(done) {
+      //this throw an error because the secret is not a cert and PS256 requires a cert.
+      jwt.sign({ foo: 'bar' }, secret, { algorithm: 'PS256' }, function (err) {
+        expect(err).to.be.ok;
+        done();
       });
-    }
+    });
 
     it('should return error on wrong arguments', function(done) {
       //this throw an error because the secret is not a cert and RS256 requires a cert.

--- a/test/jwt.asymmetric_signing.tests.js
+++ b/test/jwt.asymmetric_signing.tests.js
@@ -1,5 +1,4 @@
 var jwt = require('../index');
-var PS_SUPPORTED = require('../lib/psSupported');
 var fs = require('fs');
 var path = require('path');
 
@@ -23,17 +22,13 @@ var algorithms = {
     // openssl ec -in ecdsa-private.pem -pubout -out ecdsa-public.pem
     pub_key: loadKey('ecdsa-public.pem'),
     invalid_pub_key: loadKey('ecdsa-public-invalid.pem')
-  }
-};
-
-if (PS_SUPPORTED) {
-  algorithms.PS256 = {
+  },
+  PS256: {
     pub_key: loadKey('pub.pem'),
     priv_key: loadKey('priv.pem'),
     invalid_pub_key: loadKey('invalid_pub.pem')
-  };
-}
-
+  }
+};
 
 describe('Asymmetric Algorithms', function(){
 

--- a/test/rsa-public-key.tests.js
+++ b/test/rsa-public-key.tests.js
@@ -1,5 +1,4 @@
 var jwt = require('../');
-var PS_SUPPORTED = require('../lib/psSupported');
 
 describe('public key start with BEGIN RSA PUBLIC KEY', function () {
 
@@ -13,16 +12,14 @@ describe('public key start with BEGIN RSA PUBLIC KEY', function () {
     jwt.verify(token, cert_pub, done);
   });
 
-  if (PS_SUPPORTED) {
-    it('should work for PS family of algorithms', function (done) {
-      var fs = require('fs');
-      var cert_pub = fs.readFileSync(__dirname + '/rsa-public-key.pem');
-      var cert_priv = fs.readFileSync(__dirname + '/rsa-private.pem');
+  it('should work for PS family of algorithms', function (done) {
+    var fs = require('fs');
+    var cert_pub = fs.readFileSync(__dirname + '/rsa-public-key.pem');
+    var cert_priv = fs.readFileSync(__dirname + '/rsa-private.pem');
 
-      var token = jwt.sign({ foo: 'bar' }, cert_priv, { algorithm: 'PS256'});
+    var token = jwt.sign({ foo: 'bar' }, cert_priv, { algorithm: 'PS256'});
 
-      jwt.verify(token, cert_pub, done);
-    });
-  }
+    jwt.verify(token, cert_pub, done);
+  });
 
 });

--- a/test/schema.tests.js
+++ b/test/schema.tests.js
@@ -1,7 +1,6 @@
 var jwt = require('../index');
 var expect = require('chai').expect;
 var fs = require('fs');
-var PS_SUPPORTED = require('../lib/psSupported');
 
 describe('schema', function() {
 
@@ -22,11 +21,9 @@ describe('schema', function() {
       sign({algorithm: 'RS256'});
       sign({algorithm: 'RS384'});
       sign({algorithm: 'RS512'});
-      if (PS_SUPPORTED) {
-        sign({algorithm: 'PS256'});
-        sign({algorithm: 'PS384'});
-        sign({algorithm: 'PS512'});
-      }
+      sign({algorithm: 'PS256'});
+      sign({algorithm: 'PS384'});
+      sign({algorithm: 'PS512'});
       sign({algorithm: 'ES256'});
       sign({algorithm: 'ES384'});
       sign({algorithm: 'ES512'});

--- a/test/wrong_alg.tests.js
+++ b/test/wrong_alg.tests.js
@@ -2,7 +2,6 @@ var fs = require('fs');
 var path = require('path');
 var jwt = require('../index');
 var JsonWebTokenError = require('../lib/JsonWebTokenError');
-var PS_SUPPORTED = require('../lib/psSupported');
 var expect = require('chai').expect;
 
 
@@ -30,15 +29,13 @@ describe('when setting a wrong `header.alg`', function () {
     });
   });
 
-  if (PS_SUPPORTED) {
-    describe('signing with pub key as HS256 and whitelisting only PS256', function () {
-      it('should not verify', function () {
-        expect(function () {
-          jwt.verify(TOKEN, pub, {algorithms: ['PS256']});
-        }).to.throw(JsonWebTokenError, /invalid algorithm/);
-      });
+  describe('signing with pub key as HS256 and whitelisting only PS256', function () {
+    it('should not verify', function () {
+      expect(function () {
+        jwt.verify(TOKEN, pub, {algorithms: ['PS256']});
+      }).to.throw(JsonWebTokenError, /invalid algorithm/);
     });
-  }
+  });
 
   describe('signing with HS256 and checking with HS384', function () {
     it('should not verify', function () {

--- a/verify.js
+++ b/verify.js
@@ -3,17 +3,11 @@ var NotBeforeError    = require('./lib/NotBeforeError');
 var TokenExpiredError = require('./lib/TokenExpiredError');
 var decode            = require('./decode');
 var timespan          = require('./lib/timespan');
-var PS_SUPPORTED      = require('./lib/psSupported');
 var jws               = require('jws');
 
-var PUB_KEY_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'];
-var RSA_KEY_ALGS = ['RS256', 'RS384', 'RS512'];
+var PUB_KEY_ALGS = ['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512', 'ES256', 'ES384', 'ES512'];
+var RSA_KEY_ALGS = ['RS256', 'RS384', 'RS512', 'PS256', 'PS384', 'PS512'];
 var HS_ALGS = ['HS256', 'HS384', 'HS512'];
-
-if (PS_SUPPORTED) {
-  PUB_KEY_ALGS.splice(3, 0, 'PS256', 'PS384', 'PS512');
-  RSA_KEY_ALGS.splice(3, 0, 'PS256', 'PS384', 'PS512');
-}
 
 module.exports = function (jwtString, secretOrPublicKey, options, callback) {
   if ((typeof options === 'function') && !callback) {


### PR DESCRIPTION
### Description

This is a breaking change - it removes the support for node 4-7, since those versions are very old and not widely used anymore.

Pros:

- Removes the dependency on semver
- Removes the splice calls
- Slight reduction of code size

Cons:

- For the few people out there still using these versions, they will be forced to either update node or stay on an old library version.

If the maintainers aren't interested in dropping support for these old versions, that's fine, I just think that this change is (while breaking), harmless enough, because I really don't know of anybody who is still using node 4, 5, 6, or 7.

### References

None really.

### Testing

Unit tests should still be passing.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
