### PR TITLE
Support named exports in esm modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
-module.exports = {
-  verify: require('./verify'),
-  sign: require('./sign'),
-  JsonWebTokenError: require('./lib/JsonWebTokenError'),
-  NotBeforeError: require('./lib/NotBeforeError'),
-  TokenExpiredError: require('./lib/TokenExpiredError'),
-};
-
-Object.defineProperty(module.exports, 'decode', {
-  enumerable: false,
-  value: require('./decode'),
-});
+module.exports.decode = require('./decode');
+module.exports.verify = require('./verify');
+module.exports.sign = require('./sign');
+module.exports.JsonWebTokenError = require('./lib/JsonWebTokenError');
+module.exports.NotBeforeError = require('./lib/NotBeforeError');
+module.exports.TokenExpiredError = require('./lib/TokenExpiredError');

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "8.5.1",
   "description": "JSON Web Token implementation (symmetric and asymmetric)",
   "main": "index.js",
+  "exports": "./index.js",
   "nyc": {
     "check-coverage": true,
     "lines": 95,

--- a/test/esm.tests.js
+++ b/test/esm.tests.js
@@ -1,0 +1,16 @@
+var expect = require('chai').expect;
+
+describe('encoding', function() {
+
+  it('should import this module correctly', function () {
+    return import('jsonwebtoken').then(jwt => {
+      expect(jwt.sign).to.be.a('function');
+      expect(jwt.decode).to.be.a('function');
+      expect(jwt.verify).to.be.a('function');
+      expect(jwt.JsonWebTokenError).to.be.a('function');
+      expect(jwt.NotBeforeError).to.be.a('function');
+      expect(jwt.TokenExpiredError).to.be.a('function');
+    });
+  });
+
+});


### PR DESCRIPTION
### Description

This PR adds the ability to use named exports in `type: module` node environments:

```js
import { sign } from "jsonwebtoken";
```

It accomplishes this via https://github.com/nodejs/cjs-module-lexer

### Testing

I added a test for this - unfortunately it will fail the lint parsing because it still supports node versions < 12.
Once the linting is updated, the tests will pass in all `node >= 12`.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
