### PR TITLE
Fix: Removed defunct badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # jsonwebtoken
 
-| **Build** | **Dependency** |
-|-----------|---------------|
-| [![Build Status](https://secure.travis-ci.org/auth0/node-jsonwebtoken.svg?branch=master)](http://travis-ci.org/auth0/node-jsonwebtoken) | [![Dependency Status](https://david-dm.org/auth0/node-jsonwebtoken.svg)](https://david-dm.org/auth0/node-jsonwebtoken) |
+| **Build** |
+|-----------|
+| [![Build Status](https://secure.travis-ci.org/auth0/node-jsonwebtoken.svg?branch=master)](http://travis-ci.org/auth0/node-jsonwebtoken) |
 
 
 An implementation of [JSON Web Tokens](https://tools.ietf.org/html/rfc7519).


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
The badge based on https://david-dm.org/ is no broken. Hence this PR removes this broken badge.



### References
As discussed in https://github.com/alanshaw/david/issues/182 the project behind https://david-dm.org/ is no longer maintained and the service is down for more than 3 months now.

### Testing
- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
