### PR TITLE
chore: add migration guide link to readme for v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ $ npm install jsonwebtoken
 # Migration notes
 
 * [From v7 to v8](https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v7-to-v8)
+* [From v8 to v9](https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v8-to-v9)
 
 # Usage
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This adds a link to the README for the [migration guide to `v9`](https://github.com/auth0/node-jsonwebtoken/wiki/(Work-in-Progress)---Migration-Notes:-v8-to-v9).

### References

- https://github.com/auth0/node-jsonwebtoken/pull/851
- https://github.com/auth0/node-jsonwebtoken/pull/852

### Testing

N/A

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
