### PR TITLE
[fix] 9.0.0 release : increased library size due to complete lodash import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 .nyc_output
 coverage
+.idea

--- a/package.json
+++ b/package.json
@@ -37,7 +37,13 @@
   },
   "dependencies": {
     "jws": "^3.2.2",
-    "lodash": "^4.17.21",
+    "lodash.includes": "^4.3.0",
+    "lodash.isboolean": "^3.0.3",
+    "lodash.isinteger": "^4.0.4",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1",
+    "lodash.once": "^4.0.0",
     "ms": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/sign.js
+++ b/sign.js
@@ -2,7 +2,13 @@ const timespan = require('./lib/timespan');
 const PS_SUPPORTED = require('./lib/psSupported');
 const validateAsymmetricKey = require('./lib/validateAsymmetricKey');
 const jws = require('jws');
-const {includes, isBoolean, isInteger, isNumber, isPlainObject, isString, once} = require('lodash')
+const includes = require('lodash.includes');
+const isBoolean = require('lodash.isboolean');
+const isInteger = require('lodash.isinteger');
+const isNumber = require('lodash.isnumber');
+const isPlainObject = require('lodash.isplainobject');
+const isString = require('lodash.isstring');
+const once = require('lodash.once');
 const { KeyObject, createSecretKey, createPrivateKey } = require('crypto')
 
 const SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none'];


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Release [9.0.0](https://github.com/auth0/node-jsonwebtoken/releases/tag/v9.0.0) breached our threshold for size for cloud function deployments. Looking at commits, this PR changed the way lodash functions were imported from per-function import to complete lodash import : https://github.com/auth0/node-jsonwebtoken/pull/852 which has resulted in significant increase in library size.

This PR reverts the imports back to modular imports.

"cost-of-modules" with modular imports : 

<img width="522" alt="Screenshot 2023-06-17 at 1 10 42 PM" src="https://github.com/auth0/node-jsonwebtoken/assets/12415700/4da8a417-8d9f-4b57-b750-3d0c76aa0928">

"cost-of-modules" with complete import : 

<img width="386" alt="Screenshot 2023-06-17 at 1 15 14 PM" src="https://github.com/auth0/node-jsonwebtoken/assets/12415700/55d3b309-603b-49df-9855-8d4e82e0d487">

### References
- fixes #878 
- PR that introduced this: https://github.com/auth0/node-jsonwebtoken/pull/852   

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
