### PR TITLE
Updating package version to 9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 All notable changes to this project will be documented in this file starting from version **v4.0.0**.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 9.0.1 - 2023-07-05
+
+- fix(stubs): allow decode method to be stubbed
+
 ## 9.0.0 - 2022-12-21
 
   **Breaking changes: See [Migration from v8 to v9](https://github.com/auth0/node-jsonwebtoken/wiki/Migration-Notes:-v8-to-v9)**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonwebtoken",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "JSON Web Token implementation (symmetric and asymmetric)",
   "main": "index.js",
   "nyc": {


### PR DESCRIPTION
### Description

Releasing `9.0.1` which closes https://github.com/auth0/node-jsonwebtoken/pull/876

### References

- https://github.com/auth0/node-jsonwebtoken/pull/876

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
