### PR TITLE
Updated sign, verify & timespan to account timezone.

### DIFF
--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -1,7 +1,8 @@
 var ms = require('ms');
 
 module.exports = function (time, iat) {
-  var timestamp = iat || Math.floor(Date.now() / 1000);
+  var givenDate = new Date();
+  var timestamp = (iat || Math.floor(givenDate.getTime() / 1000)) - (givenDate.getTimezoneOffset() * 6);
 
   if (typeof time === 'string') {
     var milliseconds = ms(time);

--- a/sign.js
+++ b/sign.js
@@ -176,7 +176,9 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     }
   }
 
-  const timestamp = payload.iat || Math.floor(Date.now() / 1000);
+  const time = new Date();
+
+  const timestamp = payload.iat || Math.floor((time.getTime() - time.getTimezoneOffset() * 6000) / 1000);
 
   if (options.noTimestamp) {
     delete payload.iat;

--- a/test/issue_147.tests.js
+++ b/test/issue_147.tests.js
@@ -6,7 +6,9 @@ describe('issue 147 - signing with a sealed payload', function() {
   it('should put the expiration claim', function () {
     var token = jwt.sign(Object.seal({foo: 123}), '123', { expiresIn: 10 });
     var result = jwt.verify(token, '123');
-    expect(result.exp).to.be.closeTo(Math.floor(Date.now() / 1000) + 10, 0.2);
+
+    const time = new Date();
+    expect(result.exp).to.be.closeTo(Math.floor((time.getTime() - time.getTimezoneOffset() * 6000) / 1000) + 10, 0.2);
   });
 
 });

--- a/test/noTimestamp.tests.js
+++ b/test/noTimestamp.tests.js
@@ -6,7 +6,9 @@ describe('noTimestamp', function() {
   it('should work with string', function () {
     var token = jwt.sign({foo: 123}, '123', { expiresIn: '5m' , noTimestamp: true });
     var result = jwt.verify(token, '123');
-    expect(result.exp).to.be.closeTo(Math.floor(Date.now() / 1000) + (5*60), 0.5);
+    const time = new Date();
+
+    expect(result.exp).to.be.closeTo(Math.floor((time.getTime() - time.getTimezoneOffset() * 6000) / 1000) + (5*60), 0.5);
   });
 
 });

--- a/verify.js
+++ b/verify.js
@@ -54,7 +54,8 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('allowInvalidAsymmetricKeyTypes must be a boolean'));
   }
 
-  const clockTimestamp = options.clockTimestamp || Math.floor(Date.now() / 1000);
+  const time = new Date();
+  const clockTimestamp = options.clockTimestamp || Math.floor((time.getTime() - time.getTimezoneOffset() * 6000) / 1000);
 
   if (!jwtString){
     return done(new JsonWebTokenError('jwt must be provided'));


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This pr is to prevent a error I found whilst using node-jsonwebtoken.
It currently does use the given timezone to generate/validate jwts, but it should be the timestamp without the timezone.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
