### PR TITLE
security: updating semver to 7.5.4 to resolve CVE-2022-25883

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jws": "^3.2.2",
     "lodash": "^4.17.21",
     "ms": "^2.1.1",
-    "semver": "^7.3.8"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "atob": "^2.1.2",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR updates [semver](https://www.npmjs.com/package/semver) to a minimum version of 7.5.4 to resolve CVE-2022-25883.


### References

- CVE-2022-25883
- https://github.com/auth0/node-jsonwebtoken/issues/921
- https://github.com/auth0/node-jsonwebtoken/pull/919

### Testing

- ✅  `npm test` is passing.
- ✅  This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
