### PR TITLE
refactor: reduce library size by using lodash specific dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,13 @@
   },
   "dependencies": {
     "jws": "^3.2.2",
-    "lodash": "^4.17.21",
+    "lodash.includes": "^4.3.0",
+    "lodash.isboolean": "^3.0.3",
+    "lodash.isinteger": "^4.0.4",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1",
+    "lodash.once": "^4.0.0",
     "ms": "^2.1.1",
     "semver": "^7.3.8"
   },

--- a/sign.js
+++ b/sign.js
@@ -2,7 +2,13 @@ const timespan = require('./lib/timespan');
 const PS_SUPPORTED = require('./lib/psSupported');
 const validateAsymmetricKey = require('./lib/validateAsymmetricKey');
 const jws = require('jws');
-const {includes, isBoolean, isInteger, isNumber, isPlainObject, isString, once} = require('lodash')
+const includes = require('lodash.includes');
+const isBoolean = require('lodash.isboolean');
+const isInteger = require('lodash.isinteger');
+const isNumber = require('lodash.isnumber');
+const isPlainObject = require('lodash.isplainobject');
+const isString = require('lodash.isstring');
+const once = require('lodash.once');
 const { KeyObject, createSecretKey, createPrivateKey } = require('crypto')
 
 const SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none'];


### PR DESCRIPTION
This is to reduce the size of the bundle users have to install.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

In 9.0.0 we introduced a change which depended on lodash as a whole, which meant our bundle size increased. We need to ensure our bundle size is small enough so customers can depend on it at the edge for serverless functions.

### References

- https://github.com/auth0/node-jsonwebtoken/pull/916
- https://github.com/auth0/node-jsonwebtoken/issues/878
- https://github.com/auth0/node-jsonwebtoken/pull/852

### Testing

- ✅ `npm test` are passing
- ✅ This change adds test coverage for new/changed/fixed functionality

### Checklist

- [] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
