### PR TITLE
docs(README.md): remove the table with broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # jsonwebtoken
 
-| **Build**                                                                                                                               | **Dependency**                                                                                                         |
-|-----------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| [![Build Status](https://secure.travis-ci.org/auth0/node-jsonwebtoken.svg?branch=master)](http://travis-ci.org/auth0/node-jsonwebtoken) | [![Dependency Status](https://david-dm.org/auth0/node-jsonwebtoken.svg)](https://david-dm.org/auth0/node-jsonwebtoken) |
-
 
 An implementation of [JSON Web Tokens](https://tools.ietf.org/html/rfc7519).
 


### PR DESCRIPTION


By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Build and Dependency links in the table are broken i suggest removing them
> I tried to use links shown in the images multiple times but they kept failing
![ink](https://github.com/auth0/node-jsonwebtoken/assets/49940741/5cedc5ab-7933-43f4-9967-58497ae1cb1f)
This is how the readme looks like with table removed:
![image](https://github.com/auth0/node-jsonwebtoken/assets/49940741/be20c8d4-c7d6-43df-bc8f-2fba7e34b15f)


### Checklist

- [x] The correct base branch is being used, if not the default branch
