### PR TITLE
fix: `validator.isValid is not a function` for certain objects

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -45,13 +45,13 @@ function validate(schema, allowUnknown, object, parameterName) {
   }
   Object.keys(object)
     .forEach(function(key) {
-      const validator = schema[key];
-      if (!validator) {
+      if (!Object.prototype.hasOwnProperty.call(schema, key)) {
         if (!allowUnknown) {
           throw new Error('"' + key + '" is not allowed in "' + parameterName + '"');
         }
         return;
       }
+      const validator = schema[key];
       if (!validator.isValid(object[key])) {
         throw new Error(validator.message);
       }

--- a/test/issue_945.tests.js
+++ b/test/issue_945.tests.js
@@ -1,0 +1,12 @@
+const jwt = require("..");
+
+const KEY = "any_key";
+
+describe("issue 945 - validator.isValid is not a function", () => {
+  it("should work", () => {
+    jwt.sign({ hasOwnProperty: null }, KEY);
+    jwt.sign({ valueOf: null }, KEY);
+    jwt.sign({ toString: null }, KEY);
+    jwt.sign({ __proto__: null }, KEY);
+  });
+});


### PR DESCRIPTION
### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.

Objects with keys like `valueOf`, `toString`, and `__proto__` cause a `TypeError` to be raised when calling `jwt.sign`. This is because the key technically does exist on the `schema` param of `validate`, when checked with `if (schema[key]) {}`. Using
`Object.prototype.hasOwnProperty` solves the issue.


> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.

I used `Object.prototype.hasOwnProperty.call(schema, key)`. This method has full browser support. Alternatively, `lodash.has` could be installed and used, but I think that would be overkill.

### References

> Include any links supporting this change such as a:
>
> GitHub Issue/PR number addressed or fixed

Fixes #945

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

I have added `test/issue_945.tests.js`. It fails if the change made to `sign.js` is not present.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
