### PR TITLE
Add `node:` prefix

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -9,7 +9,7 @@ const isNumber = require('lodash.isnumber');
 const isPlainObject = require('lodash.isplainobject');
 const isString = require('lodash.isstring');
 const once = require('lodash.once');
-const { KeyObject, createSecretKey, createPrivateKey } = require('crypto')
+const { KeyObject, createSecretKey, createPrivateKey } = require('node:crypto')
 
 const SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256', 'HS384', 'HS512', 'none'];
 if (PS_SUPPORTED) {

--- a/verify.js
+++ b/verify.js
@@ -6,7 +6,7 @@ const timespan = require('./lib/timespan');
 const validateAsymmetricKey = require('./lib/validateAsymmetricKey');
 const PS_SUPPORTED = require('./lib/psSupported');
 const jws = require('jws');
-const {KeyObject, createSecretKey, createPublicKey} = require("crypto");
+const {KeyObject, createSecretKey, createPublicKey} = require("node:crypto");
 
 const PUB_KEY_ALGS = ['RS256', 'RS384', 'RS512'];
 const EC_KEY_ALGS = ['ES256', 'ES384', 'ES512'];


### PR DESCRIPTION
* Add prefix to nodejs dependencies to support running in Node and Cloudflare environments https://developers.cloudflare.com/workers/runtime-apis/nodejs/

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Add prefix to nodejs dependencies to support running in Node and Cloudflare environments 

### References

https://developers.cloudflare.com/workers/runtime-apis/nodejs/

Also changed this in the dependencies:
https://github.com/auth0/node-jwa/pull/50
https://github.com/auth0/node-jws/pull/110

### Testing

This will break older node versions, which do not support this syntax. This goes back to Node 14

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
