### PR TITLE
Optionally validate the payload of a token before verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,30 @@ jwt.verify(token, 'shhhhh', function(err, decoded) {
 });
 ```
 
+### InvalidPayloadError
+Thrown if the payload validation callback failed. The error message will be inherited from the error thrown in the `payloadCallback` or defaults to *'invalid token payload'* if for example a number was thrown and not an error
+
+Error object example:
+
+* name: 'InvalidPayloadError'
+* message: 'invalid token payload'
+
+```js
+jwt.verify(token, 'shhhhh', function(err, decoded) {
+  if (err) {
+    /*
+      err = {
+        name: 'InvalidPayloadError',
+        message: 'foo property not equal to bar',
+      }
+    */
+  }
+}, function (payload) {
+  if (payload.foo !== 'bar') {
+    throw new Error('foo property not equal to bar');
+  }
+});
+```
 
 ## Algorithms supported
 

--- a/lib/InvalidPayloadError.js
+++ b/lib/InvalidPayloadError.js
@@ -1,0 +1,12 @@
+const JsonWebTokenError = require("./JsonWebTokenError");
+
+const InvalidPayloadError = function (message, date) {
+  JsonWebTokenError.call(this, message);
+  this.name = "InvalidFormatError";
+  this.date = date;
+};
+
+InvalidPayloadError.prototype = Object.create(JsonWebTokenError.prototype);
+InvalidPayloadError.prototype.constructor = InvalidPayloadError;
+
+module.exports = InvalidPayloadError;

--- a/lib/InvalidPayloadError.js
+++ b/lib/InvalidPayloadError.js
@@ -1,9 +1,8 @@
 const JsonWebTokenError = require("./JsonWebTokenError");
 
-const InvalidPayloadError = function (message, date) {
+const InvalidPayloadError = function (message) {
   JsonWebTokenError.call(this, message);
-  this.name = "InvalidFormatError";
-  this.date = date;
+  this.name = "InvalidPayloadError";
 };
 
 InvalidPayloadError.prototype = Object.create(JsonWebTokenError.prototype);

--- a/test/payload_callback.test.js
+++ b/test/payload_callback.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const jwt = require('../index');
+const assert = require('chai').assert;
+const expect = require('chai').expect;
+
+describe('payload callback', function() {
+  const KEY = 'somethingSECRET';
+  const TEST_ERROR_MESSAGE = 'bar not car!';
+  let testPayloadCallback;
+
+  beforeEach(function() {
+    testPayloadCallback = function (payload) {
+      if (payload.foo !== 'bar') {
+        throw new Error(TEST_ERROR_MESSAGE);
+      }
+    }
+  });
+
+  it('should check that the payload satisfies the provided callback', function () {
+    const token = jwt.sign({ foo: 'bar' }, KEY);
+    const result = jwt.verify(token, KEY, undefined, undefined, testPayloadCallback);
+    expect(result.foo).to.equal('bar');
+  });
+
+  it('should be compatible with async token verification', function () {
+    const testCallback = function (err, decoded) {
+      if (err) {
+        assert.fail(err.message);
+      }
+      expect(decoded.foo).to.equal('bar');
+    }
+
+    const token = jwt.sign({ foo: 'bar' }, KEY);
+    jwt.verify(token, KEY, {}, testCallback, testPayloadCallback);
+  });
+
+  it('should throw when the payload callback rejects', function () {
+    const token = jwt.sign({ foo: 'car' }, KEY);
+    expect(function () {
+      jwt.verify(token, KEY, undefined, undefined, testPayloadCallback)
+    }).to.throw(TEST_ERROR_MESSAGE);
+  })
+})


### PR DESCRIPTION
### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.

Currently the only way to know that a token returned from `jwt.verify()` is of the correct format is by verifying the payload returned from the function. This MR makes it so the user can specify a callback `payloadCallback` that can be provided as an argument to `jwt.verify()`, which facilitates sanitising the token payload before it is verified


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed

Closes #955 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds full test coverage for new/changed/fixed functionality
- [x] This change was made on Ubuntu with Node 20.14

### Checklist

- [x] I have added documentation for new/changed functionality in the README
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
