### PR TITLE
Deprecated: payload must be valid JSON object

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -84,6 +84,10 @@ const options_for_objects = [
 ];
 
 module.exports = function (payload, secretOrPrivateKey, options, callback) {
+  if (typeof payload !== 'object') {
+    throw Error('Payload must be valid JSON object')
+  }
+  
   if (typeof options === 'function') {
     callback = options;
     options = {};

--- a/test/non_object_values.tests.js
+++ b/test/non_object_values.tests.js
@@ -3,16 +3,34 @@ var expect = require('chai').expect;
 
 describe('non_object_values values', function() {
 
-  it('should work with string', function () {
-    var token = jwt.sign('hello', '123');
-    var result = jwt.verify(token, '123');
-    expect(result).to.equal('hello');
+  it('should does not work with string', function () {
+    expect(function () {
+      jwt.sign('hello', '123');
+    }).to.throw('Payload must be valid JSON object');
   });
 
-  it('should work with number', function () {
-    var token = jwt.sign(123, '123');
-    var result = jwt.verify(token, '123');
-    expect(result).to.equal('123');
+  it('should does not work with number', function () {
+    expect(function () {
+      jwt.sign(123, '123');
+    }).to.throw('Payload must be valid JSON object');
   });
+
+  it('should does not work with function', function () {
+    expect(function () {
+      jwt.sign(function () { return 0 }, '123')
+    }).to.throw('Payload must be valid JSON object')
+  })
+
+  it('should does not work with boolean', function () {
+    expect(function () {
+      jwt.sign(true, '123')
+    }).to.throw('Payload must be valid JSON object')
+  })
+
+  it('should does not work with undefined', function () {
+    expect(function () {
+      jwt.sign(undefined, '123')
+    }).to.throw('Payload must be valid JSON object')
+  })
 
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
The payload must be valid JSON object due to [RFC 7519 section 7.1](https://www.rfc-editor.org/rfc/rfc7519#section-7.2).

### References
#985 

### Testing
Put the string as payload

- [x] This change adds test coverage for new changed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
