### PR TITLE
Update export styles for ESM compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,15 @@
+const decode = require('./decode');
+const verify = require('./verify');
+const sign = require('./sign');
+const JsonWebTokenError = require('./lib/JsonWebTokenError');
+const NotBeforeError = require('./lib/NotBeforeError');
+const TokenExpiredError = require('./lib/TokenExpiredError');
+
 module.exports = {
-  decode: require('./decode'),
-  verify: require('./verify'),
-  sign: require('./sign'),
-  JsonWebTokenError: require('./lib/JsonWebTokenError'),
-  NotBeforeError: require('./lib/NotBeforeError'),
-  TokenExpiredError: require('./lib/TokenExpiredError'),
+  decode,
+  verify,
+  sign,
+  JsonWebTokenError,
+  NotBeforeError,
+  TokenExpiredError,
 };


### PR DESCRIPTION
### Description

Node.js's ESM-to-CJS interoperability only supports a limited subset of exports.  (See [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer/blob/main/README.md) for details.)  By switching to one of the supported styles, ESM code can use named imports from jsonwebtoken.

### References

This issue is further documented as the ["Named Exports"](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/NamedExports.md) error on [Are the Types Wrong](https://arethetypeswrong.github.io/?p=jsonwebtoken%409.0.2).

Fixes #963, #875

### Testing


To demonstrate, create a `test.mjs`:

```js
// Within the jsonwebtoken directory:
import { verify } from './index.js';
// Or importing from an installed jsonwebtoken package:
import { verify } from 'jsonwebtoken';
verify('a', 'a');
```

Without this change:

```
import { verify } from './index.js';
         ^^^^^^
SyntaxError: Named export 'verify' not found. The requested module './index.js' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
```

With this change: Successful execution (in this case, a "jwt malformed" error).

Tested in Node.js 24.4.1

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
