### PR TITLE
fix(sign): prevent double callback when payload already has a property

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -214,7 +214,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     }
   }
 
-  Object.keys(options_to_payload).forEach(function (key) {
+  for (const key of Object.keys(options_to_payload)) {
     const claim = options_to_payload[key];
     if (typeof options[key] !== 'undefined') {
       if (typeof payload[claim] !== 'undefined') {
@@ -222,7 +222,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
       }
       payload[claim] = options[key];
     }
-  });
+  };
 
   const encoding = options.encoding || 'utf8';
 

--- a/test/callback-issue.test.js
+++ b/test/callback-issue.test.js
@@ -1,0 +1,24 @@
+const assert = require('assert');
+const jwt = require('../index.js');
+
+describe('Fix: jwt.sign callback should not be called twice', function () {
+  it('should call callback only once when payload.iss conflicts with options.issuer', function (done) {
+    let callbackCount = 0;
+
+    jwt.sign(
+      { iss: 'bar', iat: 1757476476 },
+      'secret',
+      { algorithm: 'HS256', issuer: 'foo' },
+      (err) => {
+        callbackCount++;
+        assert.ok(err, 'Expected an error due to issuer conflict');
+        assert.strictEqual(
+          err.message,
+          'Bad "options.issuer" option. The payload already has an "iss" property.'
+        );
+        assert.strictEqual(callbackCount, 1, 'Callback was called more than once');
+        done();
+      }
+    );
+  });
+});


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR fixes a bug in jwt.sign() where the callback is called twice when the payload already contains a property that conflicts with options. For example, when payload.iss exists and options.issuer is also provided, the callback was triggered once with an error and then again with a token.

The root cause was that Object.keys(options_to_payload).forEach(...) with return failure(err) only returned from the callback, not the parent function, allowing the signing logic to continue and call the callback a second time.

Solution:

Replaced .forEach() with a for...of loop so return failure(err) exits the sign() function immediately.

Added a regression test to ensure the callback is called only once in conflict scenarios.

No breaking changes to the API.

References

Fixes GitHub issue: #1000 

<img width="1718" height="874" alt="Screenshot 2025-11-07 192917" src="https://github.com/user-attachments/assets/a0f748f4-a211-495e-abce-5ab3cb2a01e5" />


> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

Added a regression test in test/callback-issue.test.js:

const assert = require('assert');
const jwt = require('../index.js');

describe('jwt.sign callback fix', function () {
  it('should call callback only once on payload/options conflict', function (done) {
    let callbackCount = 0;

    jwt.sign(
      { iss: 'bar', iat: 1757476476 },
      'secret',
      { algorithm: 'HS256', issuer: 'foo' },
      (err) => {
        callbackCount++;
        assert.ok(err);
        assert.strictEqual(
          err.message,
          'Bad "options.issuer" option. The payload already has an "iss" property.'
        );
        assert.strictEqual(callbackCount, 1);
        done();
      }
    );
  });
});


All existing tests pass.

Regression test verifies callback is called only once.

Developed and tested in Node.js v22.19.0 on Linux (WSL/Debian).

 This change adds test coverage for the fixed functionality.

Checklist

 I have added tests for the fixed functionality

 All active GitHub checks for tests, formatting, and security are passing

 The correct base branch is being used (master).