### PR TITLE
replace ms with ms-tiny

### DIFF
--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -1,11 +1,13 @@
-var ms = require('ms');
+var ms = require('ms-tiny');
 
 module.exports = function (time, iat) {
   var timestamp = iat || Math.floor(Date.now() / 1000);
 
   if (typeof time === 'string') {
-    var milliseconds = ms(time);
-    if (typeof milliseconds === 'undefined') {
+    var milliseconds;
+    try {
+      milliseconds = ms(time);
+    } catch (e) {
       return;
     }
     return Math.floor(timestamp + milliseconds / 1000);

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.once": "^4.0.0",
-    "ms": "^2.1.1",
+    "ms-tiny": "^1.1.0",
     "semver": "^7.5.4"
   },
   "devDependencies": {

--- a/test/jwt.asymmetric_signing.tests.js
+++ b/test/jwt.asymmetric_signing.tests.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const expect = require('chai').expect;
 const assert = require('chai').assert;
-const ms = require('ms');
+const ms = require('ms-tiny');
 
 function loadKey(filename) {
   return fs.readFileSync(path.join(__dirname, filename));


### PR DESCRIPTION
[`ms`](https://npmgraph.js.org/?q=ms) has no TypeScript types, no ESM exports, and returns `undefined` on invalid input.

[`ms-tiny`](https://npmgraph.js.org/?q=ms-tiny) is a drop-in replacement with the same API. Ships ESM + CJS with built-in types. 833 bytes gzipped, zero deps.

The only code change beyond the import swap is a try-catch in `timespan.js` because ms-tiny throws on invalid input instead of returning undefined (the `undefined` check right after still produces the same `JsonWebTokenError`).

All 511 tests pass.