### PR TITLE
fix: prevent callback from being called twice on payload conflict

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -214,7 +214,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     }
   }
 
-  Object.keys(options_to_payload).forEach(function (key) {
+  for (const key of Object.keys(options_to_payload)) {
     const claim = options_to_payload[key];
     if (typeof options[key] !== 'undefined') {
       if (typeof payload[claim] !== 'undefined') {
@@ -222,7 +222,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
       }
       payload[claim] = options[key];
     }
-  });
+  }
 
   const encoding = options.encoding || 'utf8';
 

--- a/test/issue_1000.tests.js
+++ b/test/issue_1000.tests.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const jwt = require('../');
+const expect = require('chai').expect;
+
+describe('issue 1000 - callback executed twice on payload conflict', function() {
+  it('should call the callback only once when payload has conflicting "iss" property', function(done) {
+    let callCount = 0;
+
+    jwt.sign(
+      { iss: 'bar', iat: 1757476476 },
+      'secret',
+      { algorithm: 'HS256', issuer: 'foo' },
+      (err, token) => {
+        callCount++;
+
+        // The callback should only be called once
+        if (callCount > 1) {
+          done(new Error(`Callback was called ${callCount} times instead of once`));
+          return;
+        }
+
+        // Give time for potential second callback
+        setTimeout(() => {
+          expect(callCount).to.equal(1);
+          expect(err).to.be.instanceOf(Error);
+          expect(err.message).to.equal('Bad "options.issuer" option. The payload already has an "iss" property.');
+          expect(token).to.be.undefined;
+          done();
+        }, 50);
+      }
+    );
+  });
+
+  it('should call the callback only once when payload has conflicting "sub" property', function(done) {
+    let callCount = 0;
+
+    jwt.sign(
+      { sub: 'bar' },
+      'secret',
+      { algorithm: 'HS256', subject: 'foo' },
+      (err, token) => {
+        callCount++;
+
+        if (callCount > 1) {
+          done(new Error(`Callback was called ${callCount} times instead of once`));
+          return;
+        }
+
+        setTimeout(() => {
+          expect(callCount).to.equal(1);
+          expect(err).to.be.instanceOf(Error);
+          expect(err.message).to.equal('Bad "options.subject" option. The payload already has an "sub" property.');
+          expect(token).to.be.undefined;
+          done();
+        }, 50);
+      }
+    );
+  });
+
+  it('should call the callback only once when payload has conflicting "aud" property', function(done) {
+    let callCount = 0;
+
+    jwt.sign(
+      { aud: 'bar' },
+      'secret',
+      { algorithm: 'HS256', audience: 'foo' },
+      (err, token) => {
+        callCount++;
+
+        if (callCount > 1) {
+          done(new Error(`Callback was called ${callCount} times instead of once`));
+          return;
+        }
+
+        setTimeout(() => {
+          expect(callCount).to.equal(1);
+          expect(err).to.be.instanceOf(Error);
+          expect(err.message).to.equal('Bad "options.audience" option. The payload already has an "aud" property.');
+          expect(token).to.be.undefined;
+          done();
+        }, 50);
+      }
+    );
+  });
+
+  it('should call the callback only once when payload has conflicting "jti" property', function(done) {
+    let callCount = 0;
+
+    jwt.sign(
+      { jti: 'bar' },
+      'secret',
+      { algorithm: 'HS256', jwtid: 'foo' },
+      (err, token) => {
+        callCount++;
+
+        if (callCount > 1) {
+          done(new Error(`Callback was called ${callCount} times instead of once`));
+          return;
+        }
+
+        setTimeout(() => {
+          expect(callCount).to.equal(1);
+          expect(err).to.be.instanceOf(Error);
+          expect(err.message).to.equal('Bad "options.jwtid" option. The payload already has an "jti" property.');
+          expect(token).to.be.undefined;
+          done();
+        }, 50);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1000

When `jwt.sign()` is called with a callback and the payload contains a property that conflicts with options (e.g., payload has `iss` but options has `issuer`), the callback was being called twice:

1. First with the error: `Bad "options.issuer" option. The payload already has an "iss" property.`
2. Then with the signed token (ignoring the conflict)

### Root Cause

In `sign.js` around line 217, a `forEach` loop was used to check for payload/options conflicts:

```js
Object.keys(options_to_payload).forEach(function (key) {
  // ...
  if (typeof payload[claim] !== 'undefined') {
    return failure(new Error('Bad "options.' + key + '" option...'));
  }
  // ...
});
```

The `return` inside a `forEach` callback only exits the current iteration, not the enclosing function. The loop continued and execution reached the async signing code, causing the callback to be invoked a second time.

### Fix

Replace `forEach` with `for...of` so that `return` properly exits the enclosing function:

```js
for (const key of Object.keys(options_to_payload)) {
  // ...
  if (typeof payload[claim] !== 'undefined') {
    return failure(new Error('Bad "options.' + key + '" option...'));
  }
  // ...
}
```

## Test Plan

- [x] Added test cases that verify the callback is called exactly once for all four conflicting properties (`iss`/`issuer`, `sub`/`subject`, `aud`/`audience`, `jti`/`jwtid`)
- [x] All existing tests pass (515 passing)
- [x] Manually verified the fix with the reproduction case from the issue