### PR TITLE
fix: wrap crypto TypeError in JsonWebTokenError for malformed EC/RSA signatures

### DIFF
--- a/verify.js
+++ b/verify.js
@@ -164,7 +164,14 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     try {
       valid = jws.verify(jwtString, decodedToken.header.alg, secretOrPublicKey);
     } catch (e) {
-      return done(e);
+      // Wrap low-level crypto errors (e.g. TypeError from malformed EC/RSA
+      // signatures) in a JsonWebTokenError so callers always receive a
+      // consistent, documented error type instead of an undocumented TypeError.
+      // See: https://github.com/auth0/node-jsonwebtoken/issues/767
+      if (e instanceof JsonWebTokenError) {
+        return done(e);
+      }
+      return done(new JsonWebTokenError('invalid signature'));
     }
 
     if (!valid) {
@@ -208,8 +215,8 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
 
     if (options.issuer) {
       const invalid_issuer =
-              (typeof options.issuer === 'string' && payload.iss !== options.issuer) ||
-              (Array.isArray(options.issuer) && options.issuer.indexOf(payload.iss) === -1);
+        (typeof options.issuer === 'string' && payload.iss !== options.issuer) ||
+        (Array.isArray(options.issuer) && options.issuer.indexOf(payload.iss) === -1);
 
       if (invalid_issuer) {
         return done(new JsonWebTokenError('jwt issuer invalid. expected: ' + options.issuer));


### PR DESCRIPTION
## Problem

When verifying a JWT signed with an EC (`ES256`, `ES384`, `ES512`) or RSA algorithm and the signature is malformed (e.g., truncated by one byte), `jws.verify()` can throw a raw `TypeError` from the underlying Node.js crypto module:

```
TypeError: "ES512" signatures must be "132" bytes, saw "131"
```

This `TypeError` is **not** a `JsonWebTokenError` and is passed directly to `done(e)`. As a result:

- Synchronous callers receive an undocumented `TypeError` instead of the expected `JsonWebTokenError`
- Code that catches `JsonWebTokenError` to classify errors (e.g., returning `401 Unauthorized`) will **not** catch this error
- The error type is inconsistent with all other signature-validation failures, which return `JsonWebTokenError('invalid signature')`

## Reproduction

```js
const { sign, verify } = require('jsonwebtoken')

const JWT_PRIVATE_KEY = `-----BEGIN EC PRIVATE KEY-----
...ES512 key...
-----END EC PRIVATE KEY-----`

const JWT_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
...EC public key...
-----END PUBLIC KEY-----`

const token = sign({ foo: 'bar' }, JWT_PRIVATE_KEY, { algorithm: 'ES512' })

try {
  // Truncate the last byte of the signature
  verify(token.slice(0, -1), JWT_PUBLIC_KEY, { algorithms: ['ES512'] })
} catch (err) {
  console.log(err instanceof JsonWebTokenError) // false (should be true)
  console.log(err.constructor.name)             // TypeError (should be JsonWebTokenError)
  console.log(err.message)                      // 'ES512 signatures must be 132 bytes, saw 131'
}
```

## Fix

In the `jws.verify()` catch block in `verify.js`, check if the thrown error is already a `JsonWebTokenError`. If it is not, wrap it in `new JsonWebTokenError('invalid signature')` before passing to `done()`.

This ensures:
- All signature-validation errors surface as `JsonWebTokenError`
- The error message `'invalid signature'` is consistent with valid-but-wrong-signature failures
- Existing behaviour for `JsonWebTokenError`s thrown by `jws` is preserved

## Changes

- **`verify.js`**: 3 lines changed in the `jws.verify()` catch block

Fixes #767