### PR TITLE
fix(verify): validate clockTolerance is a non-negative number

### DIFF
--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -248,6 +248,61 @@ describe('verify', function() {
       });
     });
 
+    describe('option: clockTolerance', function () {
+      const clockTimestamp = 1000000000;
+
+      it('should reject a non-number clockTolerance', function (done) {
+        const token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp + 1}, key);
+        jwt.verify(token, key, {clockTolerance: '5'}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a non-negative number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('should reject a negative clockTolerance', function (done) {
+        const token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp + 1}, key);
+        jwt.verify(token, key, {clockTolerance: -5}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a non-negative number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('should reject a non-finite clockTolerance', function (done) {
+        const token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp + 1}, key);
+        jwt.verify(token, key, {clockTolerance: Infinity}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a non-negative number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('should reject an expired token instead of silently accepting it when clockTolerance is non-finite', function (done) {
+        // exp + Infinity === Infinity made `clockTimestamp >= exp + clockTolerance`
+        // always false, silently accepting an expired token. It is now rejected.
+        const token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp - 1}, key);
+        jwt.verify(token, key, {clockTimestamp: clockTimestamp, clockTolerance: Infinity}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a non-negative number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('should accept a valid non-negative clockTolerance', function (done) {
+        const token = jwt.sign({foo: 'bar', iat: clockTimestamp, exp: clockTimestamp - 1}, key);
+        jwt.verify(token, key, {clockTimestamp: clockTimestamp, clockTolerance: 5}, function (err, p) {
+          assert.isNull(err);
+          assert.equal(p.foo, 'bar');
+          done();
+        });
+      });
+    });
+
     describe('option: maxAge and clockTimestamp', function () {
       // { foo: 'bar', iat: 1437018582, exp: 1437018800 } exp = iat + 218s
       const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MzcwMTg1ODIsImV4cCI6MTQzNzAxODgwMH0.AVOsNC7TiT-XVSpCpkwB1240izzCIJ33Lp07gjnXVpA';

--- a/verify.js
+++ b/verify.js
@@ -46,6 +46,11 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('clockTimestamp must be a number'));
   }
 
+  if (options.clockTolerance !== undefined &&
+      (typeof options.clockTolerance !== 'number' || !Number.isFinite(options.clockTolerance) || options.clockTolerance < 0)) {
+    return done(new JsonWebTokenError('clockTolerance must be a non-negative number'));
+  }
+
   if (options.nonce !== undefined && (typeof options.nonce !== 'string' || options.nonce.trim() === '')) {
     return done(new JsonWebTokenError('nonce must be a non-empty string'));
   }


### PR DESCRIPTION
## Problem

`verify()` performs no validation on the `clockTolerance` option, yet it is added directly to the timestamp comparisons:

```js
if (payload.nbf > clockTimestamp + (options.clockTolerance || 0)) { ... }
if (clockTimestamp >= payload.exp + (options.clockTolerance || 0)) { ... }
```

When `clockTolerance` is an invalid value, this silently corrupts the `exp`/`nbf` checks instead of erroring:

- `Infinity` → `exp + Infinity === Infinity`, so `clockTimestamp >= Infinity` is always `false` → an **expired token is accepted with no error**.
- `NaN` → every comparison is `false` → same silent bypass.
- a numeric **string** (e.g. `"5"`) → `exp + "5"` becomes string concatenation, producing nonsensical comparisons.
- a **negative** number → narrows the validity window in a way that is almost certainly a mistake, with no signal to the caller.

This was reported in #1021.

## Fix

Validate `clockTolerance` up front and reject invalid values, mirroring the existing `clockTimestamp must be a number` guard a few lines above:

```js
if (options.clockTolerance !== undefined &&
    (typeof options.clockTolerance !== 'number' || !Number.isFinite(options.clockTolerance) || options.clockTolerance < 0)) {
  return done(new JsonWebTokenError('clockTolerance must be a non-negative number'));
}
```

## Scope / non-goals

The original report also suggested capping `clockTolerance` at a fixed maximum (e.g. 300s). I deliberately did **not** add an upper bound: a large-but-finite tolerance is an unusual-but-legitimate configuration, and a hard cap would be a breaking change for anyone relying on it. This PR only rejects values that are unambiguously invalid (non-number / `NaN` / `Infinity` / negative) and cause silent, surprising behavior. If the maintainers want a maximum, that is a separate policy decision and easy to layer on top.

## Test plan

- [x] Added `option: clockTolerance` tests in `test/verify.tests.js` (rejects string / negative / non-finite; confirms an expired token is rejected rather than silently accepted with `Infinity`; confirms a valid small tolerance still verifies).
- [x] New tests fail on `master` (4/5) and pass with the fix.
- [x] `npm test` (full suite + lint) passes: **516 passing, 1 pending**, no regressions.

Fixes #1021