### PR TITLE
fix(verify): make regexp audience consistent with string audience for tokens without an aud claim

### DIFF
--- a/test/claim-aud.test.js
+++ b/test/claim-aud.test.js
@@ -431,6 +431,15 @@ describe('audience', function() {
           });
         });
       });
+
+      it('should error with a Regex verify "audience" option that matches any string', function (done) {
+        verifyWithAudience(token, /.+/, (err) => {
+          testUtils.asyncCheck(done, () => {
+            expect(err).to.be.instanceOf(jwt.JsonWebTokenError);
+            expect(err).to.have.property('message', 'jwt audience invalid. expected: /.+/');
+          });
+        });
+      });
     });
   });
 });

--- a/verify.js
+++ b/verify.js
@@ -197,7 +197,7 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
 
       const match = target.some(function (targetAudience) {
         return audiences.some(function (audience) {
-          return audience instanceof RegExp ? audience.test(targetAudience) : audience === targetAudience;
+          return audience instanceof RegExp ? typeof targetAudience === 'string' && audience.test(targetAudience) : audience === targetAudience;
         });
       });
 


### PR DESCRIPTION
### Description

When `verify` is given a regexp `audience`, a token that has no `aud` claim is treated differently from how a string `audience` treats the same token. A string rejects it; a regexp can accept it. This PR makes the two branches consistent.

### Reproduction

```js
const jwt = require('jsonwebtoken');
const token = jwt.sign({ foo: 'bar' }, 'shhhhh'); // no aud claim

jwt.verify(token, 'shhhhh', { audience: 'anything' }); // throws "jwt audience invalid" (correct)
jwt.verify(token, 'shhhhh', { audience: /.+/ });       // returns the payload (inconsistent)
```

A token with `aud: ""` or `aud: []` is rejected by both branches, so only the missing-`aud` case diverges.

### Existing test expectations

`test/claim-aud.test.js` already has a `describe('without a "aud" value in payload')` block asserting that a no-aud token must fail every audience check, including the regexp ones. Those existing tests pass only because they use patterns like `/^urn:no-match$/` that happen not to match the coerced value. A pattern that matches any string exposes the gap, which is what the added test covers.

### Root cause

In `verify.js`:

```js
const target = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
```

When `aud` is absent, `payload.aud` is `undefined`, so `target` becomes `[undefined]`. The regexp branch then runs:

```js
audience.test(targetAudience) // RegExp.prototype.test(undefined)
```

`RegExp.prototype.test` coerces its argument to a string first, so this evaluates `audience.test("undefined")`. A permissive pattern matches the literal string `"undefined"` and the check passes. The string-equality branch (`audience === targetAudience`) does no coercion, so it rejects the same token. Per RFC 7519 section 4.1.3, a verifier that requires an audience should reject a token whose `aud` is absent.

### Fix

Test the regexp only against string targets:

```diff
-          return audience instanceof RegExp ? audience.test(targetAudience) : audience === targetAudience;
+          return audience instanceof RegExp ? typeof targetAudience === 'string' && audience.test(targetAudience) : audience === targetAudience;
```

This brings the regexp branch in line with the string-equality branch and with the no-aud expectations already encoded in the test suite.

### Testing

Added a test under the existing `without a "aud" value in payload` block: a regexp that matches any string must still reject a no-aud token. It fails on `master` (the token is accepted) and passes with the fix.

- `npm test`: 512 passing, 1 pending, 0 failing
- `npx eslint verify.js test/claim-aud.test.js`: clean

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
