### PR TITLE
docs: warn that RegExp audiences should be anchored

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ As mentioned in [this comment](https://github.com/auth0/node-jsonwebtoken/issues
   > * rsa - ['RS256', 'RS384', 'RS512']
   > * ec - ['ES256', 'ES384', 'ES512']
   > * default - ['RS256', 'RS384', 'RS512']
-* `audience`: if you want to check audience (`aud`), provide a value here. The audience can be checked against a string, a regular expression or a list of strings and/or regular expressions. 
-  > Eg: `"urn:foo"`, `/urn:f[o]{2}/`, `[/urn:f[o]{2}/, "urn:bar"]`
+* `audience`: if you want to check audience (`aud`), provide a value here. The audience can be checked against a string, a regular expression or a list of strings and/or regular expressions.
+  > Eg: `"urn:foo"`, `/^urn:f[o]{2}$/`, `[/^urn:f[o]{2}$/, "urn:bar"]`
+  >
+  > **Security note:** String audiences use exact equality. RegExp audiences use `RegExp#test`, so unanchored patterns can match unintended values (for example `/api\.myapp\.com/` matches `evil-api.myapp.com.attacker.com`). Prefer anchored patterns such as `/^api\.myapp\.com$/`.
 * `complete`: return an object with the decoded `{ payload, header, signature }` instead of only the usual content of the payload.
 * `issuer` (optional): string or array of strings of valid values for the `iss` field.
 * `jwtid` (optional): if you want to check JWT ID (`jti`), provide a string value here.


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Documents that `audience` RegExp checks use `RegExp#test` (partial match) while string checks use exact equality, so unanchored patterns can accept unintended audiences. Updates the README examples to use anchored regexes and adds a short security note.

### References

- Fixes #1019

### Testing

- Docs-only change; no runtime behavior changed.
- Reviewed README rendering of the updated `audience` option text.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch