### PR TITLE
fix: respect an `iat` of 0 instead of overwriting it with the current time (#874)

### DIFF
--- a/lib/timespan.js
+++ b/lib/timespan.js
@@ -1,7 +1,7 @@
 var ms = require('ms');
 
 module.exports = function (time, iat) {
-  var timestamp = iat || Math.floor(Date.now() / 1000);
+  var timestamp = (typeof iat === 'number' && !isNaN(iat)) ? iat : Math.floor(Date.now() / 1000);
 
   if (typeof time === 'string') {
     var milliseconds = ms(time);

--- a/sign.js
+++ b/sign.js
@@ -182,7 +182,7 @@ module.exports = function (payload, secretOrPrivateKey, options, callback) {
     }
   }
 
-  const timestamp = payload.iat || Math.floor(Date.now() / 1000);
+  const timestamp = (typeof payload.iat === 'number' && !isNaN(payload.iat)) ? payload.iat : Math.floor(Date.now() / 1000);
 
   if (options.noTimestamp) {
     delete payload.iat;

--- a/test/claim-iat.test.js
+++ b/test/claim-iat.test.js
@@ -110,6 +110,14 @@ describe('issue at', function() {
         expectedIssueAt: 100,
         options: {}
       },
+      {
+        // regression for #874: iat of 0 (the Unix epoch) is a valid number and
+        // must be preserved, not treated as falsy and overwritten with "now".
+        description: 'should sign with provided time for "iat" of 0',
+        iat: 0,
+        expectedIssueAt: 0,
+        options: {}
+      },
       // TODO an iat of -Infinity should fail validation
       {
         description: 'should set null "iat" when given -Infinity',
@@ -150,6 +158,21 @@ describe('issue at', function() {
             expect(err).to.be.null;
             expect(jwt.decode(token).iat).to.equal(testCase.expectedIssueAt);
           });
+        });
+      });
+    });
+
+    // regression for #874: an "iat" of 0 must anchor "exp"/"nbf" too, not "now".
+    // The bug also affected timespan() (lib/timespan.js), which independently
+    // applied the same `iat || now` fallback, so exp/nbf were derived from "now".
+    it('should derive "exp" and "nbf" from an "iat" of 0', function (done) {
+      signWithIssueAt(0, {expiresIn: 86400, notBefore: 60}, (err, token) => {
+        testUtils.asyncCheck(done, () => {
+          expect(err).to.be.null;
+          const decoded = jwt.decode(token);
+          expect(decoded.iat).to.equal(0);
+          expect(decoded.exp).to.equal(86400);
+          expect(decoded.nbf).to.equal(60);
         });
       });
     });


### PR DESCRIPTION
### Description

Fixes #874. Signing a token with `iat: 0` (the Unix epoch) silently discards the value and stamps the **current time** instead.

The cause is a falsy-zero bug at two coupled sites:

```js
// sign.js:185
const timestamp = payload.iat || Math.floor(Date.now() / 1000);
// lib/timespan.js:4
var timestamp = iat || Math.floor(Date.now() / 1000);
```

`0` is falsy, so `0 || now` evaluates to `now`. Because that same `timestamp` is the base `timespan()` uses to derive `exp` and `nbf`, **those claims are corrupted too** whenever `iat` is 0.

Reproduction on `master`:

```js
const jwt = require('jsonwebtoken');
jwt.decode(jwt.sign({ iat: 0 }, 'secret', { algorithm: 'HS256', expiresIn: 86400, notBefore: 60 }));
// actual:   { iat: 1787105508, nbf: 1787105568, exp: 1787191908 }   ← all wrong
// expected: { iat: 0,          nbf: 60,          exp: 86400 }
```

A non-zero `iat` (e.g. `100`) already works — the bug only bites for `0`, which is a perfectly valid `NumericDate` (`isNumber(0) === true`, so it passes claim validation).

### Fix

Replace the falsy check with an explicit numeric guard at **both** sites:

```js
const timestamp = (typeof payload.iat === 'number' && !isNaN(payload.iat)) ? payload.iat : Math.floor(Date.now() / 1000);
```

Both sites must change — patching only `sign.js` leaves `timespan()` re-applying its own `0 || …`, so `exp`/`nbf` would stay corrupted.

The `!isNaN` guard deliberately preserves the **existing contract** already encoded in `test/claim-iat.test.js`: the only falsy `number` values are `0` and `NaN`, so this rescues `0` while keeping `NaN → current time` and `Infinity → null` unchanged.

### Tests

Added to `test/claim-iat.test.js`:
- a signing-table case asserting `iat: 0` is preserved (`decode(token).iat === 0`);
- a dedicated test asserting `exp`/`nbf` are anchored to `iat: 0` (`exp === 86400`, `nbf === 60`) — this covers the `lib/timespan.js` site.

Both **fail on `master`** and pass with the fix; the full `claim-iat` suite (41 tests) is green, and the pre-existing `NaN`/`Infinity` cases are unchanged.

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*