### PR TITLE
fix: reject a non-numeric clockTolerance instead of silently ignoring it

### DIFF
--- a/test/verify.tests.js
+++ b/test/verify.tests.js
@@ -248,6 +248,50 @@ describe('verify', function() {
       });
     });
 
+    describe('option: clockTolerance', function () {
+      // a token that's already expired by 100 seconds, so any of these
+      // should reject it unless clockTolerance is silently doing nothing
+      const token = jwt.sign({foo: 'bar'}, key, {expiresIn: -100});
+
+      it('rejects a non-numeric clockTolerance instead of ignoring it', function (done) {
+        // this used to get past validation, and `exp + '5'` turns into
+        // string concatenation once it hits the comparison below, which
+        // makes an already-expired token look valid no matter how old it is
+        jwt.verify(token, key, {clockTolerance: '5'}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('rejects Infinity as a clockTolerance', function (done) {
+        jwt.verify(token, key, {clockTolerance: Infinity}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('rejects NaN as a clockTolerance', function (done) {
+        jwt.verify(token, key, {clockTolerance: NaN}, function (err, p) {
+          assert.equal(err.name, 'JsonWebTokenError');
+          assert.equal(err.message, 'clockTolerance must be a number');
+          assert.isUndefined(p);
+          done();
+        });
+      });
+
+      it('still honors a normal numeric clockTolerance', function (done) {
+        jwt.verify(token, key, {clockTolerance: 200}, function (err, p) {
+          assert.isNull(err);
+          assert.equal(p.foo, 'bar');
+          done();
+        });
+      });
+    });
+
     describe('option: maxAge and clockTimestamp', function () {
       // { foo: 'bar', iat: 1437018582, exp: 1437018800 } exp = iat + 218s
       const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MzcwMTg1ODIsImV4cCI6MTQzNzAxODgwMH0.AVOsNC7TiT-XVSpCpkwB1240izzCIJ33Lp07gjnXVpA';

--- a/verify.js
+++ b/verify.js
@@ -46,6 +46,10 @@ module.exports = function (jwtString, secretOrPublicKey, options, callback) {
     return done(new JsonWebTokenError('clockTimestamp must be a number'));
   }
 
+  if (options.clockTolerance !== undefined && (typeof options.clockTolerance !== 'number' || !Number.isFinite(options.clockTolerance))) {
+    return done(new JsonWebTokenError('clockTolerance must be a number'));
+  }
+
   if (options.nonce !== undefined && (typeof options.nonce !== 'string' || options.nonce.trim() === '')) {
     return done(new JsonWebTokenError('nonce must be a non-empty string'));
   }


### PR DESCRIPTION
Closes #606.

verify() checks that `clockTimestamp` is a number, but there was never an equivalent check for `clockTolerance`. If you pass a string there, which is easy to do by accident since `maxAge` accepts strings, the exp/nbf comparisons turn into string concatenation instead of arithmetic. Infinity and NaN break the same comparisons in their own way. All three cases end up making the tolerance effectively unbounded, so a token that's actually expired still verifies fine.

Repro before this change:

```js
const token = jwt.sign({foo: 'bar'}, 'secret', {expiresIn: -100}); // expired 100s ago
jwt.verify(token, 'secret', {clockTolerance: '5'}, console.log); // no error, token accepted
```

The fix just validates `clockTolerance` the same way `clockTimestamp` already is, and throws a `JsonWebTokenError` instead of letting it silently do the wrong thing. Added tests covering the string, Infinity and NaN cases, plus one confirming a normal numeric tolerance still works as before.

There was an earlier attempt at this back in #611, but it never got merged and had its own bug (the validation lived inside a `.forEach` callback, so `return`ing from it didn't actually stop `verify()`, it just kept going). This is a fresh, smaller fix that doesn't have that problem.